### PR TITLE
Writes each result in its own yaml file

### DIFF
--- a/src/nemory/build_sources/internal/build_sources_from_plugins.py
+++ b/src/nemory/build_sources/internal/build_sources_from_plugins.py
@@ -1,8 +1,10 @@
 import logging
+from datetime import datetime
 
 from nemory.build_sources.internal.execute_plugins import (
     execute_plugins_for_all_datasource_files,
 )
+from nemory.build_sources.internal.export_results import export_build_results
 from nemory.build_sources.internal.types import PluginList
 from nemory.pluginlib.build_plugin import (
     BuildExecutionResult,
@@ -42,11 +44,6 @@ def _get_all_build_plugins() -> PluginList:
     return plugin_list
 
 
-def _export_results(results: list[tuple[BuildExecutionResult, BuildPlugin]]) -> None:
-    # TODO: Implement writing the results in files
-    pass
-
-
 def _build_embeddings(results: list[tuple[BuildExecutionResult, BuildPlugin]]) -> None:
     # TODO: Use the get_chunks method of each result to create embeddings
     pass
@@ -55,12 +52,14 @@ def _build_embeddings(results: list[tuple[BuildExecutionResult, BuildPlugin]]) -
 def build_all_datasources(project_dir: str) -> None:
     project_path = ensure_project_dir(project_dir)
 
+    build_start_time = datetime.now()
+
     # 1. Find all plugins that can be run
     plugins_per_type = _get_all_build_plugins()
 
     # 2. Browse the src directory to find all config file and execute the right plugin for each
     results = execute_plugins_for_all_datasource_files(project_path, plugins_per_type)
 
-    _export_results(results)
+    export_build_results(project_path, build_start_time, [result for (result, _) in results])
 
     _build_embeddings(results)

--- a/src/nemory/build_sources/internal/export_results.py
+++ b/src/nemory/build_sources/internal/export_results.py
@@ -1,0 +1,51 @@
+import logging
+from dataclasses import asdict
+from datetime import datetime
+from pathlib import Path
+
+import yaml
+
+from nemory.pluginlib.build_plugin import BuildExecutionResult
+from nemory.project.layout import get_output_dir
+
+logger = logging.getLogger(__name__)
+
+
+def export_build_results(project_dir: Path, build_start_time: datetime, results: list[BuildExecutionResult]) -> None:
+    run_dir = _create_run_dir(project_dir, build_start_time)
+
+    for result in results:
+        _export_build_result(run_dir, result)
+
+
+def _create_run_dir(project_dir: Path, build_start_time: datetime) -> Path:
+    output_dir = get_output_dir(project_dir)
+
+    run_dir = output_dir.joinpath(f"run-{build_start_time.isoformat(timespec='seconds')}")
+    run_dir.mkdir(parents=True, exist_ok=False)
+
+    return run_dir
+
+
+def _export_build_result(run_dir: Path, result: BuildExecutionResult):
+    export_file_path = _get_result_export_file_path(run_dir, result)
+
+    with export_file_path.open("w") as export_file:
+        yaml.safe_dump(asdict(result), export_file, sort_keys=False)
+
+    logger.info(f"Exported result to {export_file_path.resolve()}")
+
+
+def _get_result_export_file_path(run_dir: Path, result: BuildExecutionResult) -> Path:
+    folder_name = result.type.split("/")[0]
+
+    folder = run_dir.joinpath(folder_name)
+    folder.mkdir(exist_ok=True)
+
+    export_filename = _get_result_export_filename(result)
+
+    return folder.joinpath(export_filename)
+
+
+def _get_result_export_filename(result: BuildExecutionResult) -> str:
+    return f"{result.name}.yaml"

--- a/src/nemory/project/layout.py
+++ b/src/nemory/project/layout.py
@@ -25,5 +25,9 @@ def get_source_dir(project_dir: Path) -> Path:
     return project_dir.joinpath("src")
 
 
+def get_output_dir(project_dir: Path) -> Path:
+    return project_dir.joinpath("output")
+
+
 def get_config_file(project_dir: Path) -> Path:
     return project_dir.joinpath("nemory.ini")


### PR DESCRIPTION
# What?

This PR adds a step in the build command to write the results we got from the plugin into output files within the run folder.

Each result is written in a directory mirroring the directory in the `src` folder. For example, if a file was found in `files`, its output would be written in a `files` directory within the run output

The output is written in YAML from the `StructuredContent` provided by the plugin