### PR TITLE
Use Python repr when exporting results

### DIFF
--- a/src/nemory/build_sources/internal/export_results.py
+++ b/src/nemory/build_sources/internal/export_results.py
@@ -1,5 +1,4 @@
 import logging
-from dataclasses import asdict
 from datetime import datetime
 from pathlib import Path
 
@@ -31,7 +30,7 @@ def _export_build_result(run_dir: Path, result: BuildExecutionResult):
     export_file_path = _get_result_export_file_path(run_dir, result)
 
     with export_file_path.open("w") as export_file:
-        yaml.safe_dump(asdict(result), export_file, sort_keys=False)
+        yaml.safe_dump(result._to_yaml_serializable(), export_file, sort_keys=False)
 
     logger.info(f"Exported result to {export_file_path.resolve()}")
 

--- a/src/nemory/pluginlib/build_plugin.py
+++ b/src/nemory/pluginlib/build_plugin.py
@@ -1,7 +1,7 @@
-from dataclasses import dataclass
+from dataclasses import asdict, dataclass, replace
 from datetime import datetime
 from io import BufferedReader
-from typing import Any, Protocol, runtime_checkable, Mapping
+from typing import Any, Mapping, Protocol, runtime_checkable
 
 
 @dataclass
@@ -64,6 +64,9 @@ class BuildExecutionResult:
     A dictionary containing the actual result that should be stored as context for the data source.
     This dictionary should be serializable in JSON or YAML format.
     """
+
+    def _to_yaml_serializable(self) -> dict[str, Any]:
+        return asdict(replace(self, result=repr(self.result)))
 
 
 class BaseBuildPlugin(Protocol):


### PR DESCRIPTION
# What?

Instead of expecting the plugin's internal result to be serialisable in YAML, we are now using Python's `repr` function to write that internal result into our files