### PR TITLE
Extract the run name logic into a RunNamePolicy class

### DIFF
--- a/src/nemory/services/factories.py
+++ b/src/nemory/services/factories.py
@@ -5,6 +5,7 @@ from nemory.embeddings.provider import EmbeddingProvider
 from nemory.services.chunk_embedding_service import ChunkEmbeddingService
 from nemory.services.embedding_shard_resolver import EmbeddingShardResolver
 from nemory.services.persistence_service import PersistenceService
+from nemory.services.run_name_policy import RunNamePolicy
 from nemory.services.table_name_policy import TableNamePolicy
 from nemory.storage.repositories.chunk_repository import ChunkRepository
 from nemory.storage.repositories.datasource_run_repository import DatasourceRunRepository
@@ -14,7 +15,7 @@ from nemory.storage.repositories.run_repository import RunRepository
 
 
 def create_run_repository(conn: DuckDBPyConnection) -> RunRepository:
-    return RunRepository(conn)
+    return RunRepository(conn, run_name_policy=RunNamePolicy())
 
 
 def create_datasource_run_repository(conn: DuckDBPyConnection) -> DatasourceRunRepository:

--- a/src/nemory/services/run_name_policy.py
+++ b/src/nemory/services/run_name_policy.py
@@ -1,0 +1,8 @@
+from datetime import datetime
+
+
+class RunNamePolicy:
+    _RUN_DIR_PREFIX = "run-"
+
+    def build(self, *, run_started_at: datetime):
+        return f"{RunNamePolicy._RUN_DIR_PREFIX}{run_started_at.isoformat(timespec='seconds')}"

--- a/tests/build_sources/internal/test_build_runner.py
+++ b/tests/build_sources/internal/test_build_runner.py
@@ -8,7 +8,7 @@ import yaml
 from nemory.build_sources.internal import build_runner
 from nemory.build_sources.internal.types import PreparedFile
 from nemory.pluginlib.build_plugin import BuildExecutionResult
-from nemory.storage.repositories.run_repository import RunRepository
+from nemory.services.run_name_policy import RunNamePolicy
 
 
 def _result(name="demo", typ="files/md"):
@@ -26,7 +26,9 @@ def _result(name="demo", typ="files/md"):
 @pytest.fixture
 def mock_build_service(mocker):
     svc = mocker.Mock(name="BuildService")
-    svc.start_run.return_value = SimpleNamespace(run_id=1, run_name=RunRepository.generate_run_dir_name(datetime.now()))
+    svc.start_run.return_value = SimpleNamespace(
+        run_id=1, run_name=RunNamePolicy().build(run_started_at=datetime.now())
+    )
     return svc
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,19 +2,21 @@ from __future__ import annotations
 
 import shutil
 from pathlib import Path
+
 import duckdb
 import pytest
 
 from nemory.project.init_project import init_project_dir
+from nemory.services.embedding_shard_resolver import EmbeddingShardResolver
+from nemory.services.persistence_service import PersistenceService
+from nemory.services.run_name_policy import RunNamePolicy
+from nemory.services.table_name_policy import TableNamePolicy
+from nemory.storage.migrate import migrate
+from nemory.storage.repositories.chunk_repository import ChunkRepository
+from nemory.storage.repositories.datasource_run_repository import DatasourceRunRepository
 from nemory.storage.repositories.embedding_model_registry_repository import EmbeddingModelRegistryRepository
 from nemory.storage.repositories.embedding_repository import EmbeddingRepository
-from nemory.storage.repositories.datasource_run_repository import DatasourceRunRepository
-from nemory.storage.migrate import migrate
 from nemory.storage.repositories.run_repository import RunRepository
-from nemory.storage.repositories.chunk_repository import ChunkRepository
-from nemory.services.persistence_service import PersistenceService
-from nemory.services.embedding_shard_resolver import EmbeddingShardResolver
-from nemory.services.table_name_policy import TableNamePolicy
 
 
 @pytest.fixture(scope="session")
@@ -46,7 +48,7 @@ def conn(db_path, create_db):
 
 @pytest.fixture
 def run_repo(conn) -> RunRepository:
-    return RunRepository(conn)
+    return RunRepository(conn, run_name_policy=RunNamePolicy())
 
 
 @pytest.fixture

--- a/tests/storage/repositories/test_run_repository.py
+++ b/tests/storage/repositories/test_run_repository.py
@@ -1,7 +1,7 @@
 from datetime import datetime, timedelta
 
+from nemory.services.run_name_policy import RunNamePolicy
 from nemory.storage.models import RunDTO
-from nemory.storage.repositories.run_repository import RunRepository
 
 
 def test_create_and_get(run_repo):
@@ -27,7 +27,7 @@ def test_create__with_started_at(run_repo):
     assert created.run_id > 0
     assert created.project_id == "project-id"
     assert created.started_at == started_at
-    assert created.run_name == RunRepository.generate_run_dir_name(started_at)
+    assert created.run_name == RunNamePolicy().build(run_started_at=started_at)
     assert created.ended_at is None
     assert created.nemory_version == "0.1.0"
 
@@ -49,12 +49,13 @@ def test_get_by_run_name(run_repo):
     )
     run_repo.create(project_id=project_id_2, nemory_version=nemory_version, started_at=started_2)
 
+    run_name_policy = RunNamePolicy()
     assert (
-        run_repo.get_by_run_name(project_id=project_id_1, run_name=RunRepository.generate_run_dir_name(started_2))
+        run_repo.get_by_run_name(project_id=project_id_1, run_name=run_name_policy.build(run_started_at=started_2))
         == run_project_1_started_2
     )
     assert (
-        run_repo.get_by_run_name(project_id=project_id_2, run_name=RunRepository.generate_run_dir_name(started_1))
+        run_repo.get_by_run_name(project_id=project_id_2, run_name=run_name_policy.build(run_started_at=started_1))
         is None
     )
 


### PR DESCRIPTION
# What?

Improvement based on comment in [previous PR](https://github.com/JetBrains/nemory-python-playground/pull/19#discussion_r2555443171): the run name generation shouldn't live in the RunRepository. Instead, it's been extracted in its own "policy" helper class, using the same template than the `TableNamePolicy`