### PR TITLE
convert all mcp tests except one to the stdio transport - so they are…

### DIFF
--- a/src/nemory/mcp/mcp_runner.py
+++ b/src/nemory/mcp/mcp_runner.py
@@ -29,14 +29,14 @@ def run_mcp_server(
 
 def _get_latest_run_name(project_dir: Path, db_path: Path | None = None) -> str:
     project_id = read_config_file(project_dir).project_id
-
-    with open_duckdb_connection(db_path or get_db_path()) as conn:
+    real_db_path = db_path or get_db_path()
+    with open_duckdb_connection(real_db_path) as conn:
         run_repository = create_run_repository(conn)
         run = run_repository.get_latest_run_for_project(str(project_id))
 
         if run is None:
             raise ValueError(
-                f"No runs found for project {project_id} using db path {db_path} and project {project_dir}"
+                f"No runs found for project {project_id} using db path {real_db_path} and project {project_dir}"
             )
 
         return run.run_name

--- a/tests/utils/environment.py
+++ b/tests/utils/environment.py
@@ -1,0 +1,15 @@
+import os
+from contextlib import contextmanager
+
+
+@contextmanager
+def env_variable(key: str, value: str):
+    current_val = os.environ.get(key, None)
+    os.environ[key] = value
+    try:
+        yield
+    finally:
+        if current_val:
+            os.environ[key] = current_val
+        else:
+            del os.environ[key]


### PR DESCRIPTION
… more reliable. Leave single HTTP mcp test