### PR TITLE
[Config Files] Refactor Postgres type to be more explicit

### DIFF
--- a/src/nemory/plugins/databases/postgresql_introspector.py
+++ b/src/nemory/plugins/databases/postgresql_introspector.py
@@ -1,20 +1,27 @@
-from typing import Any, Mapping
+from typing import Any
 
 import psycopg
 from psycopg import Connection
 from psycopg.rows import dict_row
-from pydantic import Field
+from pydantic import BaseModel, Field
 
 from nemory.plugins.base_db_plugin import BaseDatabaseConfigFile
 from nemory.plugins.databases.base_introspector import BaseIntrospector, SQLQuery
 from nemory.plugins.databases.databases_types import DatabaseColumn
 
 
+class PostgresConnectionProperties(BaseModel):
+    host: str
+    port: int | None = None
+    database: str | None = None
+    user: str | None = None
+    password: str | None = None
+    additional_properties: dict[str, Any] = {}
+
+
 class PostgresConfigFile(BaseDatabaseConfigFile):
     type: str = Field(default="databases/postgres")
-    connection: dict[str, Any] = Field(
-        description="Connection parameters for the Postgres database. It can contain any of the keys supported by the Postgres connection string"
-    )
+    connection: PostgresConnectionProperties
 
 
 class PostgresqlIntrospector(BaseIntrospector[PostgresConfigFile]):
@@ -23,11 +30,8 @@ class PostgresqlIntrospector(BaseIntrospector[PostgresConfigFile]):
     supports_catalogs = True
 
     def _connect(self, file_config: PostgresConfigFile):
-        connection = file_config.connection
-        if not isinstance(connection, Mapping):
-            raise ValueError("Invalid YAML config: 'connection' must be a mapping of connection parameters")
+        connection_string = self._create_connection_string_for_config(file_config.connection)
 
-        connection_string = self._create_connection_string_for_config(connection)
         return psycopg.connect(connection_string)
 
     def _fetchall_dicts(self, connection: Connection, sql: str, params) -> list[dict]:
@@ -36,7 +40,7 @@ class PostgresqlIntrospector(BaseIntrospector[PostgresConfigFile]):
             return [r for r in cur.fetchall()]
 
     def _get_catalogs(self, connection: Connection, file_config: PostgresConfigFile) -> list[str]:
-        database = file_config.connection.get("database")
+        database = file_config.connection.database
         if database is not None:
             return [database]
 
@@ -61,22 +65,23 @@ class PostgresqlIntrospector(BaseIntrospector[PostgresConfigFile]):
             nullable=row["is_nullable"].upper() == "YES",
         )
 
-    def _create_connection_string_for_config(self, connection_config: Mapping[str, Any]) -> str:
+    def _create_connection_string_for_config(self, connection_config: PostgresConnectionProperties) -> str:
         def _escape_pg_value(value: str) -> str:
             escaped = value.replace("\\", "\\\\").replace("'", "\\'")
             return f"'{escaped}'"
 
-        host = connection_config.get("host")
+        host = connection_config.host
         if host is None:
             raise ValueError("A host must be provided to connect to the PostgreSQL database.")
 
         connection_parts = {
             "host": host,
-            "port": connection_config.get("port", 5432),
-            "dbname": connection_config.get("database"),
-            "user": connection_config.get("user"),
-            "password": connection_config.get("password"),
+            "port": connection_config.port or 5432,
+            "dbname": connection_config.database,
+            "user": connection_config.user,
+            "password": connection_config.password,
         }
+        connection_parts.update(connection_config.additional_properties)
 
         connection_string = " ".join(
             f"{k}={_escape_pg_value(str(v))}" for k, v in connection_parts.items() if v is not None

--- a/tests/databases/test_postgresql_connection_string.py
+++ b/tests/databases/test_postgresql_connection_string.py
@@ -1,5 +1,5 @@
 import pytest
-from nemory.plugins.databases.postgresql_introspector import PostgresqlIntrospector
+from nemory.plugins.databases.postgresql_introspector import PostgresqlIntrospector, PostgresConnectionProperties
 from psycopg import conninfo
 
 
@@ -7,13 +7,13 @@ from psycopg import conninfo
     "connection_config, expected_params",
     [
         pytest.param(
-            {
-                "host": "localhost",
-                "port": 5432,
-                "database": "test_db",
-                "user": "test_user",
-                "password": "secure_password",
-            },
+            PostgresConnectionProperties(
+                host="localhost",
+                port=5432,
+                database="test_db",
+                user="test_user",
+                password="secure_password",
+            ),
             {
                 "host": "localhost",
                 "port": "5432",
@@ -24,12 +24,12 @@ from psycopg import conninfo
             id="complete-config",
         ),
         pytest.param(
-            {
-                "host": "localhost",
-                "database": "test_db",
-                "user": "test_user",
-                "password": "secure_password",
-            },
+            PostgresConnectionProperties(
+                host="localhost",
+                database="test_db",
+                user="test_user",
+                password="secure_password",
+            ),
             {
                 "host": "localhost",
                 "port": "5432",
@@ -40,10 +40,10 @@ from psycopg import conninfo
             id="missing-port",
         ),
         pytest.param(
-            {
-                "host": "localhost",
-                "password": "secure_password",
-            },
+            PostgresConnectionProperties(
+                host="localhost",
+                password="secure_password",
+            ),
             {
                 "host": "localhost",
                 "port": "5432",
@@ -52,12 +52,12 @@ from psycopg import conninfo
             id="missing-database-and-user",
         ),
         pytest.param(
-            {
-                "host": "localhost",
-                "database": "test db",
-                "user": "user  name",
-                "password": "p@ss;word",
-            },
+            PostgresConnectionProperties(
+                host="localhost",
+                database="test db",
+                user="user  name",
+                password="p@ss;word",
+            ),
             {
                 "host": "localhost",
                 "port": "5432",
@@ -68,12 +68,12 @@ from psycopg import conninfo
             id="parameters-with-spaces",
         ),
         pytest.param(
-            {
-                "host": "localhost",
-                "database": "test'db",
-                "user": "user''name",
-                "password": "p@ss;word",
-            },
+            PostgresConnectionProperties(
+                host="localhost",
+                database="test'db",
+                user="user''name",
+                password="p@ss;word",
+            ),
             {
                 "host": "localhost",
                 "port": "5432",
@@ -84,13 +84,13 @@ from psycopg import conninfo
             id="parameters-with-quotes",
         ),
         pytest.param(
-            {
-                "host": "localhost",
-                "port": "1234",
-                "database": r"test\db",
-                "user": r"user\\name",
-                "password": "p@ss;word",
-            },
+            PostgresConnectionProperties(
+                host="localhost",
+                port=1234,
+                database=r"test\db",
+                user=r"user\\name",
+                password="p@ss;word",
+            ),
             {
                 "host": "localhost",
                 "port": "1234",
@@ -101,12 +101,12 @@ from psycopg import conninfo
             id="parameters-with-backslashes",
         ),
         pytest.param(
-            {
-                "host": "localhost",
-                "database": "te  st'db",
-                "user": "us''er'na:me",
-                "password": r"p@ss;wo\rd",
-            },
+            PostgresConnectionProperties(
+                host="localhost",
+                database="te  st'db",
+                user="us''er'na:me",
+                password=r"p@ss;wo\rd",
+            ),
             {
                 "host": "localhost",
                 "port": "5432",
@@ -115,6 +115,28 @@ from psycopg import conninfo
                 "password": r"p@ss;wo\rd",
             },
             id="parameters-with-mixed-escaping",
+        ),
+        pytest.param(
+            PostgresConnectionProperties(
+                host="localhost",
+                database="te  st'db",
+                user="us''er'na:me",
+                password=r"p@ss;wo\rd",
+                additional_properties={
+                    "connect_timeout": 10,
+                    "application_name": "test",
+                },
+            ),
+            {
+                "host": "localhost",
+                "port": "5432",
+                "dbname": "te  st'db",
+                "user": "us''er'na:me",
+                "password": r"p@ss;wo\rd",
+                "connect_timeout": "10",
+                "application_name": "test",
+            },
+            id="parameters-with-additional-properties",
         ),
     ],
 )


### PR DESCRIPTION
# What?

This is an example of how we could change our connection type and code for plugin to be able to mix both static and dynamic properties.

The postgres connection config is now divided into two parts:
1. a list of documented static properties
2. a list of undocumented dynamic properties

This allows to take advantage of both worlds: we statically list some selected properties so that our documentation is explicit about those properties. But we also let users add any properties that they know the underlying Postgres database accepts.