### PR TITLE
NEM-301 support partitions in postgresql introspection

### DIFF
--- a/src/nemory/plugins/databases/databases_types.py
+++ b/src/nemory/plugins/databases/databases_types.py
@@ -11,10 +11,17 @@ class DatabaseColumn:
 
 
 @dataclass
+class DatabasePartitionInfo:
+    meta: dict[str, Any]
+    partition_tables: list[str]
+
+
+@dataclass
 class DatabaseTable:
     name: str
     columns: list[DatabaseColumn]
     samples: list[dict[str, Any]]
+    partition_info: DatabasePartitionInfo | None = None
     description: str | None = None
 
 

--- a/src/nemory/plugins/databases/postgresql_introspector.py
+++ b/src/nemory/plugins/databases/postgresql_introspector.py
@@ -1,4 +1,4 @@
-from typing import Any, Annotated
+from typing import Annotated, Any
 
 import psycopg
 from psycopg import Connection
@@ -8,7 +8,7 @@ from pydantic import BaseModel, Field
 from nemory.pluginlib.config_properties import ConfigPropertyAnnotation
 from nemory.plugins.base_db_plugin import BaseDatabaseConfigFile
 from nemory.plugins.databases.base_introspector import BaseIntrospector, SQLQuery
-from nemory.plugins.databases.databases_types import DatabaseColumn
+from nemory.plugins.databases.databases_types import DatabaseColumn, DatabasePartitionInfo
 
 
 class PostgresConnectionProperties(BaseModel):
@@ -53,17 +53,64 @@ class PostgresqlIntrospector(BaseIntrospector[PostgresConfigFile]):
 
     def _sql_columns_for_schema(self, catalog: str, schema: str) -> SQLQuery:
         sql = """
-        SELECT table_name, column_name, is_nullable, udt_name, data_type
-        FROM information_schema.columns
-        WHERE table_catalog = %s AND table_schema = %s
+        SELECT rel.relname    as table_name,
+               att.attname    as column_name,
+               not att.attnotnull as is_nullable,
+               typ.typname    as udt_name
+        FROM pg_catalog.pg_attribute att
+                 JOIN pg_catalog.pg_class rel ON att.attrelid = rel.oid
+                 JOIN pg_catalog.pg_namespace nsp ON rel.relnamespace = nsp.oid
+                 JOIN pg_catalog.pg_type typ ON att.atttypid = typ.oid
+        WHERE
+            -- filter out system columns
+            att.attnum >= 1 AND
+            -- filter out partitions
+            not rel.relispartition 
+          AND
+            nsp.nspname = %s
         """
-        return SQLQuery(sql, (catalog, schema))
+        return SQLQuery(sql, [schema])
 
     def _construct_column(self, row: dict[str, Any]) -> DatabaseColumn:
         return DatabaseColumn(
             name=row["column_name"],
             type=row["udt_name"],
-            nullable=row["is_nullable"].upper() == "YES",
+            nullable=row["is_nullable"],
+        )
+
+    def _sql_partitions_for_schema(self, catalog: str, schema: str) -> SQLQuery:
+        sql = """
+        WITH partitions AS
+                 (SELECT parentrel.oid, array_agg(childrel.relname) as partition_tables
+                  FROM pg_catalog.pg_class parentrel
+                           JOIN pg_catalog.pg_inherits inh ON inh.inhparent = parentrel.oid
+                           JOIN pg_catalog.pg_class childrel ON inh.inhrelid = childrel.oid
+                  GROUP BY parentrel.oid)
+        SELECT rel.relname            as table_name,
+               CASE part.partstrat
+                   WHEN 'h' THEN 'hash partitioned'
+                   WHEN 'l' THEN 'list partitioned'
+                   WHEN 'r' THEN 'range partitioned'
+                   END                AS partitioning_strategy,
+               array_agg(att.attname) as columns_in_partition_key,
+               partitions.partition_tables
+        FROM pg_catalog.pg_partitioned_table part
+                 JOIN pg_catalog.pg_class rel ON part.partrelid = rel.oid
+                 JOIN pg_catalog.pg_namespace nsp ON rel.relnamespace = nsp.oid
+                 JOIN pg_catalog.pg_attribute att ON att.attrelid = rel.oid AND att.attnum = ANY (part.partattrs)
+                 JOIN partitions ON partitions.oid = rel.oid
+        WHERE nsp.nspname = %s
+        GROUP BY rel.relname, part.partstrat, partitions.partition_tables
+        """
+        return SQLQuery(sql, [schema])
+
+    def _construct_partition_info(self, row: dict[str, Any]) -> DatabasePartitionInfo:
+        return DatabasePartitionInfo(
+            meta={
+                "partitioning_strategy": row["partitioning_strategy"],
+                "columns_in_partition_key": row["columns_in_partition_key"],
+            },
+            partition_tables=row["partition_tables"],
         )
 
     def _create_connection_string_for_config(self, connection_config: PostgresConnectionProperties) -> str:

--- a/tests/plugins/test_postgresql_db_plugin.py
+++ b/tests/plugins/test_postgresql_db_plugin.py
@@ -1,3 +1,4 @@
+import contextlib
 from datetime import datetime
 from typing import Any, Mapping
 
@@ -13,6 +14,7 @@ from nemory.plugins.databases.databases_types import (
     DatabaseCatalog,
     DatabaseColumn,
     DatabaseIntrospectionResult,
+    DatabasePartitionInfo,
     DatabaseSchema,
     DatabaseTable,
 )
@@ -27,53 +29,136 @@ def postgres_container():
     container.stop()
 
 
-@pytest.fixture(scope="module")
-def postgres_container_with_columns(postgres_container):
-    connection_url = postgres_container.get_connection_url()
-    with psycopg.connect(connection_url) as conn:
+@pytest.fixture
+def create_db_schema(create_pg_conn, request):
+    @contextlib.contextmanager
+    def _create_db_schema(desired_schema_name: str | None = None):
+        actual_schema_name = desired_schema_name or request.function.__name__
+        conn = create_pg_conn()
+        conn.execute(f"CREATE SCHEMA {actual_schema_name};")
+        conn.commit()
+        conn.close()
+        try:
+            yield actual_schema_name
+        finally:
+            new_conn = create_pg_conn()
+            new_conn.execute(f"DROP SCHEMA IF EXISTS {actual_schema_name} CASCADE;")
+            new_conn.commit()
+            new_conn.close()
+
+    return _create_db_schema
+
+
+@pytest.fixture
+def create_pg_conn(postgres_container: PostgresContainer):
+    def create_connection():
+        connection_url = postgres_container.get_connection_url()
+        conn = psycopg.connect(connection_url)
+        return conn
+
+    yield create_connection
+
+
+def _init_with_test_table(create_pg_conn, schema_name):
+    with create_pg_conn() as conn:
         cursor = conn.cursor()
-
-        cursor.execute("""
-                CREATE SCHEMA custom;
-                CREATE TABLE custom.test (id int not null, name varchar(255) null)
-                """)
-
-    return postgres_container
+        cursor.execute(f"CREATE TABLE {schema_name}.test (id int not null, name varchar(255) null)")
 
 
-def test_postgres_plugin_execute(postgres_container_with_columns: PostgresContainer):
-    plugin = PostgresqlDbPlugin()
+def test_postgres_plugin_execute(create_db_schema, create_pg_conn, postgres_container: PostgresContainer):
+    schema_name = "custom"
+    with create_db_schema(schema_name):
+        _init_with_test_table(create_pg_conn, schema_name)
+        plugin = PostgresqlDbPlugin()
 
-    config_file = _create_config_file_from_container(postgres_container_with_columns)
+        config_file = _create_config_file_from_container(postgres_container)
 
-    execution_result = execute_datasource_plugin(plugin, config_file["type"], config_file, "file_name")
+        execution_result = execute_datasource_plugin(plugin, config_file["type"], config_file, "file_name")
 
-    assert execution_result.result == DatabaseIntrospectionResult(
-        catalogs=[
-            DatabaseCatalog(
-                name="test",
-                schemas=[
-                    DatabaseSchema(
-                        name="public",
-                        tables=[],
-                    ),
-                    DatabaseSchema(
-                        name="custom",
-                        tables=[
-                            DatabaseTable(
-                                name="test",
-                                columns=[
-                                    DatabaseColumn(name="id", type="int4", nullable=False),
-                                    DatabaseColumn(name="name", type="varchar", nullable=True),
-                                ],
-                                samples=[],
-                            )
-                        ],
-                    ),
-                ],
-            )
-        ]
-    )
+        assert execution_result.result == DatabaseIntrospectionResult(
+            catalogs=[
+                DatabaseCatalog(
+                    name="test",
+                    schemas=[
+                        DatabaseSchema(
+                            name="public",
+                            tables=[],
+                        ),
+                        DatabaseSchema(
+                            name=schema_name,
+                            tables=[
+                                DatabaseTable(
+                                    name="test",
+                                    columns=[
+                                        DatabaseColumn(name="id", type="int4", nullable=False),
+                                        DatabaseColumn(name="name", type="varchar", nullable=True),
+                                    ],
+                                    samples=[],
+                                )
+                            ],
+                        ),
+                    ],
+                )
+            ]
+        )
+
+
+def test_postgres_partitions(create_pg_conn, create_db_schema, postgres_container):
+    with create_db_schema() as db_schema:
+        with create_pg_conn() as conn:
+            conn.execute(f"""
+                        CREATE TABLE {db_schema}.test_partitions (id int not null, name varchar(255) null)
+                        PARTITION BY RANGE (id);
+
+                        CREATE TABLE {db_schema}.test_partitions_1 PARTITION OF {db_schema}.test_partitions
+                        FOR VALUES FROM (0) TO (10);
+
+                        CREATE TABLE {db_schema}.test_partitions_2 PARTITION OF {db_schema}.test_partitions
+                        FOR VALUES FROM (10) TO (20);
+                    """)
+
+        plugin = PostgresqlDbPlugin()
+
+        config_file = _create_config_file_from_container(postgres_container)
+
+        execution_result = execute_datasource_plugin(plugin, config_file["type"], config_file, "file_name")
+
+        assert execution_result.result == DatabaseIntrospectionResult(
+            [
+                DatabaseCatalog(
+                    "test",
+                    [
+                        DatabaseSchema(
+                            name="public",
+                            tables=[],
+                        ),
+                        DatabaseSchema(
+                            db_schema,
+                            tables=[
+                                DatabaseTable(
+                                    "test_partitions",
+                                    [
+                                        DatabaseColumn("id", "int4", False),
+                                        DatabaseColumn("name", "varchar", True),
+                                    ],
+                                    [],
+                                    partition_info=DatabasePartitionInfo(
+                                        meta={
+                                            "columns_in_partition_key": ["id"],
+                                            "partitioning_strategy": "range partitioned",
+                                        },
+                                        partition_tables=[
+                                            "test_partitions_1",
+                                            "test_partitions_2",
+                                        ],
+                                    ),
+                                )
+                            ],
+                        ),
+                    ],
+                )
+            ]
+        )
 
 
 def test_postgres_plugin_divide_into_chunks():


### PR DESCRIPTION
Having this database schema:
```sql
CREATE TABLE test_partitions (id int not null, name varchar(255) null)
PARTITION BY RANGE (id);

CREATE TABLE test_partitions_1 PARTITION OF test_partitions
FOR VALUES FROM (0) TO (10);

CREATE TABLE test_partitions_2 PARTITION OF est_partitions
FOR VALUES FROM (10) TO (20);
```
Before this change we would have 3 tables in the introspection - `[test_partitions, test_partitions_1, test_partitions_2]` each with the same list of columns.

After this change we'll have a more compact representation:
```python
DatabaseTable(
      "test_partitions",
      [
          DatabaseColumn("id", "int4", False),
          DatabaseColumn("name", "varchar", True),
      ],
      [],
      partition_info=DatabasePartitionInfo(
          meta={
              "columns_in_partition_key": ["id"],
              "partitioning_strategy": "range partitioned",
          },
          partition_tables=[
              "test_partitions_1",
              "test_partitions_2",
          ],
      ),
  )
```

Given that number of partitions could be really big it should help model less likely to hallucinate. And from the user's perspective it looks more readable.