### PR TITLE
NEM-279: Checks the connection to a DB datasource by executing SQL

### DIFF
--- a/src/nemory/plugins/base_db_plugin.py
+++ b/src/nemory/plugins/base_db_plugin.py
@@ -48,7 +48,7 @@ class BaseDatabasePlugin(BuildDatasourcePlugin[T]):
         )
 
     def check_connection(self, full_type: str, datasource_name: str, file_config: T) -> None:
-        self._introspector._connect(file_config)
+        self._introspector.check_connection(file_config)
 
     def divide_result_into_chunks(self, build_result: BuildExecutionResult) -> list[EmbeddableChunk]:
         return build_database_chunks(build_result.result)

--- a/src/nemory/plugins/databases/base_introspector.py
+++ b/src/nemory/plugins/databases/base_introspector.py
@@ -22,6 +22,10 @@ class BaseIntrospector[T](ABC):
     supports_catalogs: bool = True
     _IGNORED_SCHEMAS: set[str] = {"information_schema"}
 
+    def check_connection(self, file_config: T) -> None:
+        with self._connect(file_config) as connection:
+            self._fetchall_dicts(connection, "SELECT 1 as test", None)
+
     def introspect_database(self, file_config: T) -> DatabaseIntrospectionResult:
         connection = self._connect(file_config)
         with connection:


### PR DESCRIPTION
# What?

Instead of solely relying on whether a connection can be created, the DB plugin now runs a `SELECT 1 as test` query

# How?

To make sure all DB introspectors will handle this query via the `_fetchall_dicts` method, I've added the "as test` alias to the value, in case libraries don't properly handle a direct value without a column name when building the "column_name -> value" dictionary