### PR TITLE
Make the LLM generated description for chunks optional

### DIFF
--- a/src/nemory/services/factories.py
+++ b/src/nemory/services/factories.py
@@ -4,7 +4,7 @@ from nemory.build_sources.internal.build_service import BuildService
 from nemory.llm.descriptions.provider import DescriptionProvider
 from nemory.llm.embeddings.provider import EmbeddingProvider
 from nemory.retrieve_embeddings.internal.retrieve_service import RetrieveService
-from nemory.services.chunk_embedding_service import ChunkEmbeddingService
+from nemory.services.chunk_embedding_service import ChunkEmbeddingMode, ChunkEmbeddingService
 from nemory.services.embedding_shard_resolver import EmbeddingShardResolver
 from nemory.services.persistence_service import PersistenceService
 from nemory.services.run_name_policy import RunNamePolicy
@@ -57,7 +57,8 @@ def create_chunk_embedding_service(
     conn: DuckDBPyConnection,
     *,
     embedding_provider: EmbeddingProvider,
-    description_provider: DescriptionProvider,
+    description_provider: DescriptionProvider | None,
+    chunk_embedding_mode: ChunkEmbeddingMode,
 ) -> ChunkEmbeddingService:
     resolver = create_shard_resolver(conn)
     persistence = create_persistence_service(conn)
@@ -66,6 +67,7 @@ def create_chunk_embedding_service(
         embedding_provider=embedding_provider,
         shard_resolver=resolver,
         description_provider=description_provider,
+        chunk_embedding_mode=chunk_embedding_mode,
     )
 
 
@@ -73,12 +75,16 @@ def create_build_service(
     conn: DuckDBPyConnection,
     *,
     embedding_provider: EmbeddingProvider,
-    description_provider: DescriptionProvider,
+    description_provider: DescriptionProvider | None,
+    chunk_embedding_mode: ChunkEmbeddingMode,
 ) -> BuildService:
     run_repo = create_run_repository(conn)
     datasource_run_repo = create_datasource_run_repository(conn)
     chunk_embedding_service = create_chunk_embedding_service(
-        conn, embedding_provider=embedding_provider, description_provider=description_provider
+        conn,
+        embedding_provider=embedding_provider,
+        description_provider=description_provider,
+        chunk_embedding_mode=chunk_embedding_mode,
     )
 
     return BuildService(

--- a/tests/integration/test_e2e_build.py
+++ b/tests/integration/test_e2e_build.py
@@ -9,6 +9,7 @@ import duckdb
 import pytest
 
 from nemory.build_sources.public.api import build_all_datasources
+from nemory.services.chunk_embedding_service import ChunkEmbeddingMode
 from nemory.storage.migrate import migrate
 
 
@@ -101,7 +102,7 @@ def use_fake_provider(mocker, fake_provider):
 def test_e2e_build_with_fake_provider(
     project_dir, db_path, conn, run_repo, chunk_repo, embedding_repo, registry_repo, use_fake_provider, fake_provider
 ):
-    build_all_datasources(project_dir=project_dir)
+    build_all_datasources(project_dir=project_dir, chunk_embedding_mode=ChunkEmbeddingMode.EMBEDDABLE_TEXT_ONLY)
 
     runs = run_repo.list()
     assert len(runs) == 1
@@ -133,7 +134,7 @@ def test_one_source_fails_but_others_succeed(
 
     mocker.patch.object(execmod, "execute", side_effect=flaky_execute)
 
-    build_all_datasources(project_dir=project_dir)
+    build_all_datasources(project_dir=project_dir, chunk_embedding_mode=ChunkEmbeddingMode.EMBEDDABLE_TEXT_ONLY)
 
     runs = run_repo.list()
     assert len(runs) == 1 and runs[0].ended_at is not None


### PR DESCRIPTION
# What?

We previously added a feature that uses a LLM-generated description to compliment the chunks we are embedding in our DuckDB.

This PR removes this LL-generated description by default and adds an opt-in as a command option to use it.

# How?

To handle different tests, I've actually added 3 different modes:
- embeddable_text only
- generated_description only
- embeddable and generated_description concatenated

This also makes sure that we don't download the LLM Model used to generate the description when "embeddable_text_only" is selected.