### PR TITLE
Introduce a DatasourceType instead of using a str for the full_type

### DIFF
--- a/src/nemory/build_sources/internal/build_runner.py
+++ b/src/nemory/build_sources/internal/build_runner.py
@@ -44,12 +44,16 @@ def build(
         try:
             prepared_source = prepare_source(discovered_datasource)
 
-            logger.info(f'Found datasource of type "{prepared_source.full_type}" with name {prepared_source.path.stem}')
+            logger.info(
+                f'Found datasource of type "{prepared_source.datasource_type.full_type}" with name {prepared_source.path.stem}'
+            )
 
-            plugin = plugins.get(prepared_source.full_type)
+            plugin = plugins.get(prepared_source.datasource_type)
             if plugin is None:
                 logger.warning(
-                    "No plugin for '%s' (datasource=%s) — skipping.", prepared_source.full_type, prepared_source.path
+                    "No plugin for '%s' (datasource=%s) — skipping.",
+                    prepared_source.datasource_type.full_type,
+                    prepared_source.path,
                 )
                 continue
 

--- a/src/nemory/build_sources/internal/build_service.py
+++ b/src/nemory/build_sources/internal/build_service.py
@@ -65,7 +65,7 @@ class BuildService:
         datasource_run = self._datasource_run_repo.create(
             run_id=run_id,
             plugin=plugin.name,
-            full_type=prepared_source.full_type,
+            full_type=prepared_source.datasource_type.full_type,
             source_id=result.name or prepared_source.path.stem,
             storage_directory=str(prepared_source.path.parent),
         )

--- a/src/nemory/build_sources/internal/plugin_execution.py
+++ b/src/nemory/build_sources/internal/plugin_execution.py
@@ -19,7 +19,7 @@ def execute(prepared_datasource: PreparedDatasource, plugin: BuildPlugin) -> Bui
 
         return execute_datasource_plugin(
             plugin=ds_plugin,
-            full_type=prepared_datasource.full_type,
+            datasource_type=prepared_datasource.datasource_type,
             config=prepared_datasource.config,
             datasource_name=prepared_datasource.datasource_name,
         )
@@ -27,6 +27,6 @@ def execute(prepared_datasource: PreparedDatasource, plugin: BuildPlugin) -> Bui
         file_plugin = cast(BuildFilePlugin, plugin)
         return execute_file_plugin(
             plugin=file_plugin,
-            full_type=prepared_datasource.full_type,
+            datasource_type=prepared_datasource.datasource_type,
             file_path=prepared_datasource.path,
         )

--- a/src/nemory/datasource_config/validate_config.py
+++ b/src/nemory/datasource_config/validate_config.py
@@ -110,10 +110,12 @@ def _validate_datasource_config(
             )
             continue
 
-        plugin = plugins.get(prepared_source.full_type)
+        plugin = plugins.get(prepared_source.datasource_type)
         if plugin is None:
             logger.debug(
-                "No plugin for '%s' (datasource=%s) — skipping.", prepared_source.full_type, prepared_source.path
+                "No plugin for '%s' (datasource=%s) — skipping.",
+                prepared_source.datasource_type.full_type,
+                prepared_source.path,
             )
             result[result_key] = ValidationResult(
                 validation_status=ValidationStatus.INVALID, summary="No compatible plugin found"
@@ -124,7 +126,7 @@ def _validate_datasource_config(
             try:
                 check_connection_for_datasource(
                     plugin=plugin,
-                    full_type=prepared_source.full_type,
+                    datasource_type=prepared_source.datasource_type,
                     config=prepared_source.config,
                     datasource_name=prepared_source.datasource_name,
                 )

--- a/src/nemory/pluginlib/build_plugin.py
+++ b/src/nemory/pluginlib/build_plugin.py
@@ -121,3 +121,25 @@ class NotSupportedError(RuntimeError):
 
 
 BuildPlugin = BuildDatasourcePlugin | BuildFilePlugin
+
+
+@dataclass(kw_only=True, frozen=True)
+class DatasourceType:
+    full_type: str
+
+    def __post_init__(self):
+        type_segments = self.full_type.split("/")
+        if len(type_segments) != 2:
+            raise ValueError(f"Invalid DatasourceType: {self.full_type}")
+
+    @property
+    def main_type(self):
+        return self.full_type.split("/")[0]
+
+    @property
+    def subtype(self):
+        return self.full_type.split("/")[1]
+
+    @staticmethod
+    def from_main_and_subtypes(main_type: str, subtype: str) -> "DatasourceType":
+        return DatasourceType(full_type=f"{main_type}/{subtype}")

--- a/src/nemory/pluginlib/plugin_utils.py
+++ b/src/nemory/pluginlib/plugin_utils.py
@@ -6,13 +6,13 @@ from typing import Any, Mapping
 
 from pydantic import TypeAdapter
 
-from nemory.pluginlib.build_plugin import BuildDatasourcePlugin, BuildExecutionResult, BuildFilePlugin
+from nemory.pluginlib.build_plugin import BuildDatasourcePlugin, BuildExecutionResult, BuildFilePlugin, DatasourceType
 
 logger = logging.getLogger(__name__)
 
 
 def execute_datasource_plugin(
-    plugin: BuildDatasourcePlugin, full_type: str, config: Mapping[str, Any], datasource_name: str
+    plugin: BuildDatasourcePlugin, datasource_type: DatasourceType, config: Mapping[str, Any], datasource_name: str
 ) -> BuildExecutionResult:
     if not isinstance(plugin, BuildDatasourcePlugin):
         raise ValueError("This method can only execute a BuildDatasourcePlugin")
@@ -20,14 +20,14 @@ def execute_datasource_plugin(
     validated_config = _validate_datasource_config_file(config, plugin)
 
     return plugin.execute(
-        full_type=full_type,
+        full_type=datasource_type.full_type,
         datasource_name=datasource_name,
         file_config=validated_config,
     )
 
 
 def check_connection_for_datasource(
-    plugin: BuildDatasourcePlugin, full_type: str, config: Mapping[str, Any], datasource_name: str
+    plugin: BuildDatasourcePlugin, datasource_type: DatasourceType, config: Mapping[str, Any], datasource_name: str
 ) -> None:
     if not isinstance(plugin, BuildDatasourcePlugin):
         raise ValueError("Connection checks can only be performed on BuildDatasourcePlugin")
@@ -35,7 +35,7 @@ def check_connection_for_datasource(
     validated_config = _validate_datasource_config_file(config, plugin)
 
     plugin.check_connection(
-        full_type=full_type,
+        full_type=datasource_type.full_type,
         datasource_name=datasource_name,
         file_config=validated_config,
     )
@@ -45,10 +45,12 @@ def _validate_datasource_config_file(config: Mapping[str, Any], plugin: BuildDat
     return TypeAdapter(plugin.config_file_type).validate_python(config)
 
 
-def execute_file_plugin(plugin: BuildFilePlugin, full_type: str, file_path: Path) -> BuildExecutionResult:
+def execute_file_plugin(
+    plugin: BuildFilePlugin, datasource_type: DatasourceType, file_path: Path
+) -> BuildExecutionResult:
     with file_path.open("rb") as fh:
         return plugin.execute(
-            full_type=full_type,
+            full_type=datasource_type.full_type,
             file_name=file_path.name,
             file_buffer=fh,
         )

--- a/src/nemory/project/datasource_discovery.py
+++ b/src/nemory/project/datasource_discovery.py
@@ -4,6 +4,7 @@ from typing import Any
 
 import yaml
 
+from nemory.pluginlib.build_plugin import DatasourceType
 from nemory.project.layout import get_source_dir
 from nemory.project.types import (
     DatasourceDescriptor,
@@ -100,8 +101,10 @@ def prepare_source(datasource: DatasourceDescriptor) -> PreparedDatasource:
     """
     if datasource.kind is DatasourceKind.FILE:
         file_subtype = datasource.path.suffix.lower().lstrip(".")
-        full_type = f"{datasource.main_type}/{file_subtype}"
-        return PreparedFile(full_type=full_type, path=datasource.path)
+        return PreparedFile(
+            datasource_type=DatasourceType.from_main_and_subtypes(main_type=datasource.main_type, subtype=file_subtype),
+            path=datasource.path,
+        )
 
     else:
         config = _parse_config_file(datasource.path)
@@ -110,9 +113,11 @@ def prepare_source(datasource: DatasourceDescriptor) -> PreparedDatasource:
         if not subtype or not isinstance(subtype, str):
             raise ValueError("Config missing 'type' at %s - skipping", datasource.path)
 
-        full_type = f"{datasource.main_type}/{subtype}"
         return PreparedConfig(
-            full_type=full_type, path=datasource.path, config=config, datasource_name=datasource.path.stem
+            datasource_type=DatasourceType.from_main_and_subtypes(main_type=datasource.main_type, subtype=subtype),
+            path=datasource.path,
+            config=config,
+            datasource_name=datasource.path.stem,
         )
 
 

--- a/src/nemory/project/types.py
+++ b/src/nemory/project/types.py
@@ -3,6 +3,8 @@ from enum import StrEnum
 from pathlib import Path
 from typing import Any
 
+from nemory.pluginlib.build_plugin import DatasourceType
+
 
 class DatasourceKind(StrEnum):
     CONFIG = "config"
@@ -18,7 +20,7 @@ class DatasourceDescriptor:
 
 @dataclass(frozen=True)
 class PreparedConfig:
-    full_type: str
+    datasource_type: DatasourceType
     path: Path
     config: dict[Any, Any]
     datasource_name: str
@@ -26,7 +28,7 @@ class PreparedConfig:
 
 @dataclass(frozen=True)
 class PreparedFile:
-    full_type: str
+    datasource_type: DatasourceType
     path: Path
 
 

--- a/tests/build_sources/internal/test_build_runner.py
+++ b/tests/build_sources/internal/test_build_runner.py
@@ -6,7 +6,7 @@ import pytest
 import yaml
 
 from nemory.build_sources.internal import build_runner
-from nemory.pluginlib.build_plugin import BuildExecutionResult
+from nemory.pluginlib.build_plugin import BuildExecutionResult, DatasourceType
 from nemory.project.types import PreparedFile
 from nemory.services.run_name_policy import RunNamePolicy
 
@@ -72,7 +72,7 @@ def test_build_skips_source_without_plugin(
     datasources = SimpleNamespace(path=tmp_path / "src" / "files" / "md" / "one.md")
     stub_sources([datasources])
     stub_plugins({})
-    stub_prepare([PreparedFile(full_type="files/md", path=datasources.path)])
+    stub_prepare([PreparedFile(datasource_type=DatasourceType(full_type="files/md"), path=datasources.path)])
 
     build_runner.build(project_dir=tmp_path, build_service=mock_build_service, project_id="proj", nemory_version="v1")
     mock_build_service.start_run.assert_not_called()
@@ -88,8 +88,8 @@ def test_build_processes_file_source_and_exports(
 ):
     src = SimpleNamespace(path=tmp_path / "src" / "files" / "md" / "one.md")
     stub_sources([src])
-    stub_prepare([PreparedFile(full_type="files/md", path=src.path)])
-    stub_plugins({"files/md": object()})
+    stub_prepare([PreparedFile(datasource_type=DatasourceType(full_type="files/md"), path=src.path)])
+    stub_plugins({DatasourceType(full_type="files/md"): object()})
 
     mock_build_service.process_prepared_source.return_value = _result(name="one", typ="files/md")
 
@@ -108,11 +108,11 @@ def test_build_continues_on_service_exception(
     stub_sources([s1, s2])
     stub_prepare(
         [
-            PreparedFile(full_type="files/md", path=s1.path),
-            PreparedFile(full_type="files/md", path=s2.path),
+            PreparedFile(datasource_type=DatasourceType(full_type="files/md"), path=s1.path),
+            PreparedFile(datasource_type=DatasourceType(full_type="files/md"), path=s2.path),
         ]
     )
-    stub_plugins({"files/md": object()})
+    stub_plugins({DatasourceType(full_type="files/md"): object()})
 
     mock_build_service.process_prepared_source.side_effect = [RuntimeError("boom"), _result(name="b")]
 

--- a/tests/build_sources/internal/test_build_service.py
+++ b/tests/build_sources/internal/test_build_service.py
@@ -5,7 +5,7 @@ from types import SimpleNamespace
 import pytest
 
 from nemory.build_sources.internal.build_service import BuildService
-from nemory.pluginlib.build_plugin import BuildExecutionResult, EmbeddableChunk
+from nemory.pluginlib.build_plugin import BuildExecutionResult, EmbeddableChunk, DatasourceType
 from nemory.project.types import PreparedDatasource, PreparedFile
 
 
@@ -21,7 +21,7 @@ def mk_result(*, name="foo", typ="files/md", result=None):
 
 
 def mk_prepared(path: Path, full_type: str) -> PreparedDatasource:
-    return PreparedFile(path=path, full_type=full_type)
+    return PreparedFile(path=path, datasource_type=DatasourceType(full_type=full_type))
 
 
 @pytest.fixture

--- a/tests/datasource_config/test_validate_config.py
+++ b/tests/datasource_config/test_validate_config.py
@@ -5,7 +5,7 @@ from typing import Any
 import pytest
 
 from nemory.datasource_config.validate_config import ValidationResult, ValidationStatus, _validate_datasource_config
-from nemory.pluginlib.build_plugin import BuildDatasourcePlugin, BuildPlugin
+from nemory.pluginlib.build_plugin import BuildDatasourcePlugin, BuildPlugin, DatasourceType
 from nemory.project.layout import create_datasource_config_file
 from nemory.serialisation.yaml import to_yaml_string
 from tests.utils.dummy_build_plugin import (
@@ -41,10 +41,10 @@ def patch_load_plugins(mocker):
     )
 
 
-def load_dummy_plugins() -> dict[str, BuildPlugin]:
+def load_dummy_plugins() -> dict[DatasourceType, BuildPlugin]:
     return {
-        "dummy/simple_config": DummyPluginWithSimpleConfig(),  # type: ignore[abstract]
-        "dummy/dummy_default": DummyDefaultDatasourcePlugin(),
+        DatasourceType(full_type="dummy/simple_config"): DummyPluginWithSimpleConfig(),  # type: ignore[abstract]
+        DatasourceType(full_type="dummy/dummy_default"): DummyDefaultDatasourcePlugin(),
     }
 
 

--- a/tests/plugins/test_clickhouse_db_plugin.py
+++ b/tests/plugins/test_clickhouse_db_plugin.py
@@ -11,6 +11,7 @@ from nemory.plugins.databases.databases_types import (
     DatabaseColumn,
     DatabaseIntrospectionResult,
 )
+from nemory.pluginlib.build_plugin import DatasourceType
 from tests.plugins.test_database_utils import assert_database_structure
 
 HTTP_PORT = 8123
@@ -88,7 +89,9 @@ def test_clickhouse_plugin_execute(
         _init_with_test_table(create_clickhouse_client, db_name, with_samples)
         plugin = ClickhouseDbPlugin()
         config_file = _create_config_file_from_container(clickhouse_container)
-        execution_result = execute_datasource_plugin(plugin, config_file["type"], config_file, "file_name")
+        execution_result = execute_datasource_plugin(
+            plugin, DatasourceType(full_type=config_file["type"]), config_file, "file_name"
+        )
         assert isinstance(execution_result.result, DatabaseIntrospectionResult)
         expected = {
             "default": {
@@ -113,7 +116,9 @@ def test_clickhouse_exact_samples(
         _init_with_test_table(create_clickhouse_client, db_name, with_samples=True)
         plugin = ClickhouseDbPlugin()
         config_file = _create_config_file_from_container(clickhouse_container)
-        execution_result = execute_datasource_plugin(plugin, config_file["type"], config_file, "file_name")
+        execution_result = execute_datasource_plugin(
+            plugin, DatasourceType(full_type=config_file["type"]), config_file, "file_name"
+        )
         assert isinstance(execution_result.result, DatabaseIntrospectionResult)
         catalogs = {c.name: c for c in execution_result.result.catalogs}
         schema = {s.name: s for s in catalogs["default"].schemas}["custom"]
@@ -135,7 +140,9 @@ def test_clickhouse_samples_in_big(
         plugin = ClickhouseDbPlugin()
         limit = plugin._introspector._SAMPLE_LIMIT
         config_file = _create_config_file_from_container(clickhouse_container)
-        execution_result = execute_datasource_plugin(plugin, config_file["type"], config_file, "file_name")
+        execution_result = execute_datasource_plugin(
+            plugin, DatasourceType(full_type=config_file["type"]), config_file, "file_name"
+        )
         assert isinstance(execution_result.result, DatabaseIntrospectionResult)
         catalogs = {c.name: c for c in execution_result.result.catalogs}
         schema = {s.name: s for s in catalogs["default"].schemas}["custom"]

--- a/tests/plugins/test_default_build_datasource_plugin.py
+++ b/tests/plugins/test_default_build_datasource_plugin.py
@@ -1,6 +1,7 @@
 import yaml
 
 from nemory.pluginlib.plugin_utils import execute_datasource_plugin
+from nemory.pluginlib.build_plugin import DatasourceType
 from tests.utils.dummy_build_plugin import DummyDefaultDatasourcePlugin
 
 
@@ -11,6 +12,8 @@ def test_default_build_datasource_plugin():
         """
     )
 
-    result = execute_datasource_plugin(DummyDefaultDatasourcePlugin(), "my_type", config_yaml, "datasource_name")
+    result = execute_datasource_plugin(
+        DummyDefaultDatasourcePlugin(), DatasourceType(full_type="dummy/dummy_default"), config_yaml, "datasource_name"
+    )
 
     assert result.result == {"ok": True}

--- a/tests/plugins/test_duckdb_db_plugin.py
+++ b/tests/plugins/test_duckdb_db_plugin.py
@@ -1,5 +1,5 @@
 from pathlib import Path
-from typing import Mapping, Any
+from typing import Any, Mapping
 
 import duckdb
 import pytest
@@ -9,6 +9,7 @@ from nemory.plugins.databases.databases_types import (
     DatabaseColumn,
 )
 from nemory.plugins.duckdb_db_plugin import DuckDbPlugin
+from nemory.pluginlib.build_plugin import DatasourceType
 from tests.plugins.test_database_utils import assert_database_structure
 
 
@@ -45,7 +46,7 @@ def test_duckdb_plugin_introspection(temp_duckdb_file: Path, with_samples):
         execute_duckdb_queries(temp_duckdb_file, "INSERT INTO test (id) VALUES (1), (2), (3)")
     plugin = DuckDbPlugin()
     config = _create_config_file_from_container(temp_duckdb_file)
-    result = execute_datasource_plugin(plugin, config["type"], config, "file_name").result
+    result = execute_datasource_plugin(plugin, DatasourceType(full_type=config["type"]), config, "file_name").result
 
     expected_structure = {
         "test_db": {
@@ -69,7 +70,7 @@ def test_duckdb_plugin_introspection_custom_schema(duckdb_with_custom_schema: Pa
         )
     plugin = DuckDbPlugin()
     config = _create_config_file_from_container(duckdb_with_custom_schema)
-    result = execute_datasource_plugin(plugin, config["type"], config, "file_name").result
+    result = execute_datasource_plugin(plugin, DatasourceType(full_type=config["type"]), config, "file_name").result
 
     expected_structure = {
         "test_db": {
@@ -95,7 +96,7 @@ def test_duckdb_exact_samples(temp_duckdb_file: Path):
     execute_duckdb_queries(temp_duckdb_file, "INSERT INTO test (id) VALUES (1), (2), (3)")
     plugin = DuckDbPlugin()
     config = _create_config_file_from_container(temp_duckdb_file)
-    result = execute_datasource_plugin(plugin, config["type"], config, "file_name").result
+    result = execute_datasource_plugin(plugin, DatasourceType(full_type=config["type"]), config, "file_name").result
     catalogs = {c.name: c for c in result.catalogs}
     main_schema = {s.name: s for s in catalogs["test_db"].schemas}["main"]
     table = {t.name: t for t in main_schema.tables}["test"]
@@ -111,7 +112,7 @@ def test_duckdb_samples_in_big(temp_duckdb_file: Path):
     plugin = DuckDbPlugin()
     limit = plugin._introspector._SAMPLE_LIMIT
     config = _create_config_file_from_container(temp_duckdb_file)
-    result = execute_datasource_plugin(plugin, config["type"], config, "file_name").result
+    result = execute_datasource_plugin(plugin, DatasourceType(full_type=config["type"]), config, "file_name").result
     catalogs = {c.name: c for c in result.catalogs}
     main_schema = {s.name: s for s in catalogs["test_db"].schemas}["main"]
     table = {t.name: t for t in main_schema.tables}["test_big"]

--- a/tests/plugins/test_mssql_db_plugin.py
+++ b/tests/plugins/test_mssql_db_plugin.py
@@ -8,6 +8,7 @@ from testcontainers.mssql import SqlServerContainer  # type: ignore
 from nemory.pluginlib.plugin_utils import execute_datasource_plugin
 from nemory.plugins.databases.databases_types import DatabaseColumn, DatabaseIntrospectionResult
 from nemory.plugins.mssql_db_plugin import MSSQLDbPlugin
+from nemory.pluginlib.build_plugin import DatasourceType
 from tests.plugins.test_database_utils import assert_database_structure
 
 MSSQL_HTTP_PORT = 1433
@@ -126,7 +127,9 @@ def test_mssql_introspection(mssql_container, create_mssql_conn, with_samples):
     _init_mssql_catalogs(create_mssql_conn, with_samples)
     plugin = MSSQLDbPlugin()
     config_file = _create_config_file_from_container(mssql_container)
-    result = execute_datasource_plugin(plugin, config_file["type"], config_file, "file_name").result
+    result = execute_datasource_plugin(
+        plugin, DatasourceType(full_type=config_file["type"]), config_file, "file_name"
+    ).result
 
     # should guest schema be ignored?
     expected_structure = {
@@ -162,7 +165,9 @@ def test_mssql_exact_samples(mssql_container: SqlServerContainer, create_mssql_c
     _init_mssql_catalogs(create_mssql_conn, with_samples=True)
     plugin = MSSQLDbPlugin()
     config_file = _create_config_file_from_container(mssql_container)
-    execution_result = execute_datasource_plugin(plugin, config_file["type"], config_file, "file_name")
+    execution_result = execute_datasource_plugin(
+        plugin, DatasourceType(full_type=config_file["type"]), config_file, "file_name"
+    )
     assert isinstance(execution_result.result, DatabaseIntrospectionResult)
 
     catalogs = {c.name: c for c in execution_result.result.catalogs}
@@ -185,7 +190,9 @@ def test_mssql_samples_in_big(mssql_container: SqlServerContainer, create_mssql_
     plugin = MSSQLDbPlugin()
     limit = plugin._introspector._SAMPLE_LIMIT
     config_file = _create_config_file_from_container(mssql_container)
-    execution_result = execute_datasource_plugin(plugin, config_file["type"], config_file, "file_name")
+    execution_result = execute_datasource_plugin(
+        plugin, DatasourceType(full_type=config_file["type"]), config_file, "file_name"
+    )
     assert isinstance(execution_result.result, DatabaseIntrospectionResult)
     catalogs = {c.name: c for c in execution_result.result.catalogs}
     schema = {s.name: s for s in catalogs["custom"].schemas}["dbo"]

--- a/tests/plugins/test_mysql_db_plugin.py
+++ b/tests/plugins/test_mysql_db_plugin.py
@@ -8,6 +8,7 @@ from testcontainers.mysql import MySqlContainer  # type: ignore
 from nemory.pluginlib.plugin_utils import execute_datasource_plugin
 from nemory.plugins.databases.databases_types import DatabaseColumn, DatabaseIntrospectionResult
 from nemory.plugins.mysql_db_plugin import MySQLDbPlugin
+from nemory.pluginlib.build_plugin import DatasourceType
 from tests.plugins.test_database_utils import assert_database_structure
 
 
@@ -92,7 +93,9 @@ def test_mysql_introspection(mysql_container: MySqlContainer, create_mysql_conn,
     _init_mysql_catalogs(create_mysql_conn, mysql_container, with_samples)
     plugin = MySQLDbPlugin()
     config_file = _create_config_file_from_container(mysql_container)
-    result = execute_datasource_plugin(plugin, config_file["type"], config_file, "file_name").result
+    result = execute_datasource_plugin(
+        plugin, DatasourceType(full_type=config_file["type"]), config_file, "file_name"
+    ).result
 
     expected_structure = {
         "default": {
@@ -145,7 +148,9 @@ def test_mysql_exact_samples(mysql_container: MySqlContainer, create_mysql_conn)
     _init_mysql_catalogs(create_mysql_conn, mysql_container, with_samples=True)
     plugin = MySQLDbPlugin()
     config_file = _create_config_file_from_container(mysql_container)
-    execution_result = execute_datasource_plugin(plugin, config_file["type"], config_file, "file_name")
+    execution_result = execute_datasource_plugin(
+        plugin, DatasourceType(full_type=config_file["type"]), config_file, "file_name"
+    )
     assert isinstance(execution_result.result, DatabaseIntrospectionResult)
 
     catalogs = {c.name: c for c in execution_result.result.catalogs}
@@ -171,7 +176,9 @@ def test_mysql_samples_in_big(mysql_container: MySqlContainer, create_mysql_conn
     plugin = MySQLDbPlugin()
     limit = plugin._introspector._SAMPLE_LIMIT
     config_file = _create_config_file_from_container(mysql_container)
-    execution_result = execute_datasource_plugin(plugin, config_file["type"], config_file, "file_name")
+    execution_result = execute_datasource_plugin(
+        plugin, DatasourceType(full_type=config_file["type"]), config_file, "file_name"
+    )
     assert isinstance(execution_result.result, DatabaseIntrospectionResult)
     catalogs = {c.name: c for c in execution_result.result.catalogs}
     schema = {s.name: s for s in catalogs["default"].schemas}["custom"]

--- a/tests/plugins/test_plugin_loader.py
+++ b/tests/plugins/test_plugin_loader.py
@@ -4,6 +4,7 @@ from nemory.plugins.plugin_loader import (
     DuplicatePluginTypeError,
     merge_plugins,
 )
+from nemory.pluginlib.build_plugin import DatasourceType
 
 
 class P1:
@@ -29,9 +30,13 @@ class P3Overlap:
 
 def test_merge_plugins():
     reg = merge_plugins([P1()], [P2()])
-    assert set(reg.keys()) == {"files/md", "databases/pg", "files/txt"}
-    assert reg["files/md"].name == "p1"
-    assert reg["files/txt"].name == "p2"
+    assert set(reg.keys()) == {
+        DatasourceType(full_type="files/md"),
+        DatasourceType(full_type="databases/pg"),
+        DatasourceType(full_type="files/txt"),
+    }
+    assert reg[DatasourceType(full_type="files/md")].name == "p1"
+    assert reg[DatasourceType(full_type="files/txt")].name == "p2"
 
 
 def test_merge_plugins_duplicate_raises():

--- a/tests/plugins/test_postgresql_db_plugin.py
+++ b/tests/plugins/test_postgresql_db_plugin.py
@@ -9,7 +9,7 @@ import pytest
 from pytest_unordered import unordered
 from testcontainers.postgres import PostgresContainer  # type: ignore
 
-from nemory.pluginlib.build_plugin import BuildExecutionResult, EmbeddableChunk
+from nemory.pluginlib.build_plugin import BuildExecutionResult, EmbeddableChunk, DatasourceType
 from nemory.pluginlib.plugin_utils import execute_datasource_plugin
 from nemory.plugins.databases.database_chunker import DatabaseColumnChunkContent, DatabaseTableChunkContent
 from nemory.plugins.databases.databases_types import (
@@ -92,7 +92,9 @@ def test_postgres_plugin_execute(create_db_schema, create_pg_conn, postgres_cont
 
         config_file = _create_config_file_from_container(postgres_container)
 
-        execution_result = execute_datasource_plugin(plugin, config_file["type"], config_file, "file_name")
+        execution_result = execute_datasource_plugin(
+            plugin, DatasourceType(full_type=config_file["type"]), config_file, "file_name"
+        )
         expected_catalogs = {
             "test": {
                 "public": {},
@@ -113,7 +115,9 @@ def test_postgres_exact_samples(create_db_schema, create_pg_conn, postgres_conta
         _init_with_test_table(create_pg_conn, schema_name, with_samples=True)
         plugin = PostgresqlDbPlugin()
         config_file = _create_config_file_from_container(postgres_container)
-        execution_result = execute_datasource_plugin(plugin, config_file["type"], config_file, "file_name")
+        execution_result = execute_datasource_plugin(
+            plugin, DatasourceType(full_type=config_file["type"]), config_file, "file_name"
+        )
         assert isinstance(execution_result.result, DatabaseIntrospectionResult)
         catalogs = {c.name: c for c in execution_result.result.catalogs}
         schema = {s.name: s for s in catalogs["test"].schemas}[schema_name]
@@ -134,7 +138,9 @@ def test_postgres_samples_in_big(create_db_schema, create_pg_conn, postgres_cont
         plugin = PostgresqlDbPlugin()
         limit = plugin._introspector._SAMPLE_LIMIT
         config_file = _create_config_file_from_container(postgres_container)
-        execution_result = execute_datasource_plugin(plugin, config_file["type"], config_file, "file_name")
+        execution_result = execute_datasource_plugin(
+            plugin, DatasourceType(full_type=config_file["type"]), config_file, "file_name"
+        )
         assert isinstance(execution_result.result, DatabaseIntrospectionResult)
         catalogs = {c.name: c for c in execution_result.result.catalogs}
         schema = {s.name: s for s in catalogs["test"].schemas}[schema_name]
@@ -173,7 +179,9 @@ def test_postgres_tables_with_indexes(create_db_schema, create_pg_conn, postgres
 
         plugin = PostgresqlDbPlugin()
         config_file = _create_config_file_from_container(postgres_container)
-        execution_result = execute_datasource_plugin(plugin, config_file["type"], config_file, "file_name")
+        execution_result = execute_datasource_plugin(
+            plugin, DatasourceType(full_type=config_file["type"]), config_file, "file_name"
+        )
         expected_catalogs = {
             "test": {
                 "public": {},
@@ -212,7 +220,9 @@ def test_postgres_partitions(create_pg_conn, create_db_schema, postgres_containe
 
         config_file = _create_config_file_from_container(postgres_container)
 
-        execution_result = execute_datasource_plugin(plugin, config_file["type"], config_file, "file_name")
+        execution_result = execute_datasource_plugin(
+            plugin, DatasourceType(full_type=config_file["type"]), config_file, "file_name"
+        )
 
         assert execution_result.result == DatabaseIntrospectionResult(
             [

--- a/tests/utils/dummy_build_plugin.py
+++ b/tests/utils/dummy_build_plugin.py
@@ -11,6 +11,7 @@ from nemory.pluginlib.build_plugin import (
     BuildPlugin,
     DefaultBuildDatasourcePlugin,
     EmbeddableChunk,
+    DatasourceType,
 )
 from nemory.pluginlib.config_properties import (
     ConfigPropertyAnnotation,
@@ -224,15 +225,15 @@ class DummyPluginWithNoConfigType(DefaultBuildDatasourcePlugin, CustomiseConfigP
         ]
 
 
-def load_dummy_plugins(exclude_file_plugins: bool = False) -> dict[str, BuildPlugin]:
-    result: dict[str, BuildPlugin] = {
-        "databases/dummy_db": DummyBuildDatasourcePlugin(),
-        "dummy/dummy_default": DummyDefaultDatasourcePlugin(),
-        "additional/dummy_type": AdditionalDummyPlugin(),
-        "dummy/no_config_type": DummyPluginWithNoConfigType(),
+def load_dummy_plugins(exclude_file_plugins: bool = False) -> dict[DatasourceType, BuildPlugin]:
+    result: dict[DatasourceType, BuildPlugin] = {
+        DatasourceType(full_type="databases/dummy_db"): DummyBuildDatasourcePlugin(),
+        DatasourceType(full_type="dummy/dummy_default"): DummyDefaultDatasourcePlugin(),
+        DatasourceType(full_type="additional/dummy_type"): AdditionalDummyPlugin(),
+        DatasourceType(full_type="dummy/no_config_type"): DummyPluginWithNoConfigType(),
     }
 
     if not exclude_file_plugins:
-        result.update({"files/dummy": DummyFilePlugin()})
+        result.update({DatasourceType(full_type="files/dummy"): DummyFilePlugin()})
 
     return result


### PR DESCRIPTION
# What?

Our plugins are based on a type we've been calling "full_type".

However, we sometimes have to deal with its subparts: the main type (or config folder) and the subtype.

Those 3 types are string in our code and can easily be confused with each other.

This PR introduces a new `DatasourceType` that wraps the `full_type` of a datasource and provides basic utilities method to convert from a full_type to its subcomponents (main and subtype) and vice versa.

This will also help better define our external API with the CLI.

# Notes

I haven't used this new type in the plugin themselves yet. But I think it would be interesting to also do it.