### PR TITLE
Refact: Chunk context as YAML in the LLM prompt

### DIFF
--- a/src/databao_context_engine/build_sources/internal/build_service.py
+++ b/src/databao_context_engine/build_sources/internal/build_service.py
@@ -8,6 +8,7 @@ from databao_context_engine.pluginlib.build_plugin import (
     BuildPlugin,
 )
 from databao_context_engine.project.types import PreparedDatasource
+from databao_context_engine.serialisation.yaml import to_yaml_string
 from databao_context_engine.services.chunk_embedding_service import ChunkEmbeddingService
 from databao_context_engine.storage.models import RunDTO
 from databao_context_engine.storage.repositories.datasource_run_repository import DatasourceRunRepository
@@ -70,7 +71,7 @@ class BuildService:
         )
 
         self._chunk_embedding_service.embed_chunks(
-            datasource_run_id=datasource_run.datasource_run_id, chunks=chunks, result=repr(result.context)
+            datasource_run_id=datasource_run.datasource_run_id, chunks=chunks, result=to_yaml_string(result.context)
         )
 
         return result

--- a/tests/build_sources/internal/test_build_service.py
+++ b/tests/build_sources/internal/test_build_service.py
@@ -1,3 +1,4 @@
+import os
 from datetime import datetime, timedelta
 from pathlib import Path
 from types import SimpleNamespace
@@ -89,7 +90,7 @@ def test_process_prepared_source_happy_path_creates_row_and_embeds(svc, repos, c
     plugin.name = "pluggy"
     prepared = mk_prepared(tmp_path / "src" / "files" / "two.md", full_type="files/md")
 
-    result = mk_result(name="files/two.md", typ="files/md")
+    result = mk_result(name="files/two.md", typ="files/md", result={"context": "ok"})
     mocker.patch("databao_context_engine.build_sources.internal.build_service.execute", return_value=result)
 
     chunks = [EmbeddableChunk("a", "A"), EmbeddableChunk("b", "B")]
@@ -110,7 +111,7 @@ def test_process_prepared_source_happy_path_creates_row_and_embeds(svc, repos, c
     chunk_embed_svc.embed_chunks.assert_called_once_with(
         datasource_run_id=555,
         chunks=chunks,
-        result=repr(result.context),
+        result=f"context: ok{os.linesep}",
     )
     assert out is result
 


### PR DESCRIPTION
# What?

Provide context as YAML to the LLM prompt generating the chunk description (rather than as a Python repr)