### PR TITLE
Add DatabaoContextProjectManager.check_datasource_connection

### DIFF
--- a/src/databao_context_engine/__init__.py
+++ b/src/databao_context_engine/__init__.py
@@ -2,6 +2,7 @@ from databao_context_engine.build_sources.internal.build_runner import BuildCont
 from databao_context_engine.databao_context_project_manager import DatabaoContextProjectManager
 from databao_context_engine.databao_engine import ContextSearchResult, DatabaoContextEngine
 from databao_context_engine.datasource_config.datasource_context import DatasourceContext
+from databao_context_engine.datasource_config.validate_config import CheckDatasourceConnectionResult
 from databao_context_engine.project.types import Datasource, DatasourceId
 from databao_context_engine.services.chunk_embedding_service import ChunkEmbeddingMode
 
@@ -14,4 +15,5 @@ __all__ = [
     "DatabaoContextProjectManager",
     "ChunkEmbeddingMode",
     "BuildContextResult",
+    "CheckDatasourceConnectionResult",
 ]

--- a/src/databao_context_engine/cli/commands.py
+++ b/src/databao_context_engine/cli/commands.py
@@ -5,7 +5,7 @@ from typing import Literal
 import click
 from click import Context
 
-from databao_context_engine.cli.datasources import add_datasource_config_cli, validate_datasource_config_cli
+from databao_context_engine.cli.datasources import add_datasource_config_cli, check_datasource_connection_cli
 from databao_context_engine.cli.info import echo_info
 from databao_context_engine.config.logging import configure_logging
 from databao_context_engine.databao_context_project_manager import DatabaoContextProjectManager
@@ -134,7 +134,7 @@ def check_datasource_config(ctx: Context, datasources_config_files: list[str] | 
         else None
     )
 
-    validate_datasource_config_cli(ctx.obj["project_dir"], datasource_ids=datasource_ids)
+    check_datasource_connection_cli(ctx.obj["project_dir"], datasource_ids=datasource_ids)
 
 
 @dce.command()

--- a/src/databao_context_engine/cli/datasources.py
+++ b/src/databao_context_engine/cli/datasources.py
@@ -4,10 +4,10 @@ from pathlib import Path
 import click
 
 from databao_context_engine.cli.add_datasource_config import add_datasource_config_interactive
+from databao_context_engine.databao_context_project_manager import DatabaoContextProjectManager
 from databao_context_engine.datasource_config.validate_config import (
-    ValidationResult,
+    CheckDatasourceConnectionResult,
     ValidationStatus,
-    validate_datasource_config,
 )
 from databao_context_engine.project.types import DatasourceId
 
@@ -16,38 +16,34 @@ def add_datasource_config_cli(project_dir: Path) -> None:
     datasource_id = add_datasource_config_interactive(project_dir)
 
     if click.confirm("\nDo you want to check the connection to this new datasource?"):
-        validate_datasource_config_cli(project_dir, datasource_ids=[datasource_id])
+        check_datasource_connection_cli(project_dir, datasource_ids=[datasource_id])
 
 
-def validate_datasource_config_cli(project_dir: Path, *, datasource_ids: list[DatasourceId] | None) -> None:
-    results = validate_datasource_config(project_dir, datasource_ids=datasource_ids)
+def check_datasource_connection_cli(project_dir: Path, *, datasource_ids: list[DatasourceId] | None) -> None:
+    results = DatabaoContextProjectManager(project_dir=project_dir).check_datasource_connection(
+        datasource_ids=datasource_ids
+    )
 
-    _print_datasource_validation_results(results)
+    _print_check_datasource_connection_results(results)
 
 
-def _print_datasource_validation_results(results: dict[DatasourceId, ValidationResult]) -> None:
+def _print_check_datasource_connection_results(results: list[CheckDatasourceConnectionResult]) -> None:
     if len(results) > 0:
-        valid_datasources = {
-            key: value for key, value in results.items() if value.validation_status == ValidationStatus.VALID
-        }
-        invalid_datasources = {
-            key: value for key, value in results.items() if value.validation_status == ValidationStatus.INVALID
-        }
-        unknown_datasources = {
-            key: value for key, value in results.items() if value.validation_status == ValidationStatus.UNKNOWN
-        }
+        valid_datasources = [result for result in results if result.validation_status == ValidationStatus.VALID]
+        invalid_datasources = [result for result in results if result.validation_status == ValidationStatus.INVALID]
+        unknown_datasources = [result for result in results if result.validation_status == ValidationStatus.UNKNOWN]
 
         # Print all errors
-        for datasource_id, validation_result in invalid_datasources.items():
+        for check_result in invalid_datasources:
             click.echo(
-                f"Error for datasource {str(datasource_id)}:{os.linesep}{validation_result.full_message}{os.linesep}"
+                f"Error for datasource {str(check_result.datasource_id)}:{os.linesep}{check_result.full_message}{os.linesep}"
             )
 
         results_summary = (
             os.linesep.join(
                 [
-                    f"{str(datasource_id)}: {validation_result.format(show_summary_only=True)}"
-                    for datasource_id, validation_result in results.items()
+                    f"{str(check_result.datasource_id)}: {check_result.format(show_summary_only=True)}"
+                    for check_result in results
                 ]
             )
             if results

--- a/src/databao_context_engine/databao_context_project_manager.py
+++ b/src/databao_context_engine/databao_context_project_manager.py
@@ -1,6 +1,10 @@
 from pathlib import Path
 
 from databao_context_engine.build_sources.public.api import BuildContextResult, build_all_datasources
+from databao_context_engine.datasource_config.validate_config import (
+    CheckDatasourceConnectionResult,
+    validate_datasource_config,
+)
 from databao_context_engine.project.datasource_discovery import DatasourceId
 from databao_context_engine.services.chunk_embedding_service import ChunkEmbeddingMode
 
@@ -16,3 +20,11 @@ class DatabaoContextProjectManager:
     ) -> list[BuildContextResult]:
         # TODO: Filter which datasources to build by datasource_ids
         return build_all_datasources(project_dir=self.project_dir, chunk_embedding_mode=chunk_embedding_mode)
+
+    def check_datasource_connection(
+        self, datasource_ids: list[DatasourceId] | None
+    ) -> list[CheckDatasourceConnectionResult]:
+        return sorted(
+            validate_datasource_config(project_dir=self.project_dir, datasource_ids=datasource_ids).values(),
+            key=lambda result: str(result.datasource_id),
+        )

--- a/tests/datasource_config/test_validate_config.py
+++ b/tests/datasource_config/test_validate_config.py
@@ -4,7 +4,7 @@ from pathlib import Path
 import pytest
 
 from databao_context_engine.datasource_config.validate_config import (
-    ValidationResult,
+    CheckDatasourceConnectionResult,
     ValidationStatus,
     validate_datasource_config,
 )
@@ -97,8 +97,10 @@ def test_validate_datasource_config_with_valid_connections(project_path: Path):
     result = validate_datasource_config(project_path)
 
     assert result == {
-        DatasourceId.from_string_repr("dummy/valid.yaml"): ValidationResult(
-            validation_status=ValidationStatus.VALID, summary=None
+        DatasourceId.from_string_repr("dummy/valid.yaml"): CheckDatasourceConnectionResult(
+            datasource_id=DatasourceId.from_string_repr("dummy/valid.yaml"),
+            validation_status=ValidationStatus.VALID,
+            summary=None,
         ),
     }
 
@@ -168,8 +170,10 @@ def test_validate_datasource_config_with_single_filter(project_path: Path):
     )
 
     assert result == {
-        DatasourceId.from_string_repr("dummy/valid.yaml"): ValidationResult(
-            validation_status=ValidationStatus.VALID, summary=None
+        DatasourceId.from_string_repr("dummy/valid.yaml"): CheckDatasourceConnectionResult(
+            datasource_id=DatasourceId.from_string_repr("dummy/valid.yaml"),
+            validation_status=ValidationStatus.VALID,
+            summary=None,
         ),
     }
 


### PR DESCRIPTION
# What?

This PR adds the new method `check_datasource_connection` in `DatabaoContextProjectManager`

# How?

The only change made to the existing implementation is to add the `datasource_id` in the `CheckDatasourceConnectionResult` (renamed from `ValidationResult`) so that a result can be self-sufficient and we can expose it as a list rather than a dictionary