### PR TITLE
DatabaoContextProjectManager.build_context can now select which datasources to build

### DIFF
--- a/src/databao_context_engine/build_sources/internal/build_runner.py
+++ b/src/databao_context_engine/build_sources/internal/build_runner.py
@@ -11,7 +11,11 @@ from databao_context_engine.build_sources.internal.export_results import (
 )
 from databao_context_engine.pluginlib.build_plugin import DatasourceType
 from databao_context_engine.plugins.plugin_loader import load_plugins
-from databao_context_engine.project.datasource_discovery import discover_datasources, prepare_source
+from databao_context_engine.project.datasource_discovery import (
+    discover_datasources,
+    get_datasource_descriptors,
+    prepare_source,
+)
 from databao_context_engine.project.types import DatasourceId
 
 logger = logging.getLogger(__name__)
@@ -31,6 +35,7 @@ def build(
     build_service: BuildService,
     project_id: str,
     dce_version: str,
+    datasource_ids: list[DatasourceId] | None = None,
 ) -> list[BuildContextResult]:
     """
     Build entrypoint.
@@ -42,11 +47,15 @@ def build(
     """
     plugins = load_plugins()
 
-    datasources = discover_datasources(project_dir)
+    if datasource_ids:
+        logger.info(f"Building datasource(s): {datasource_ids}")
+        datasources = get_datasource_descriptors(project_dir, datasource_ids)
+    else:
+        datasources = discover_datasources(project_dir)
 
-    if not datasources:
-        logger.info("No sources discovered under %s", project_dir)
-        return []
+        if not datasources:
+            logger.info("No sources discovered under %s", project_dir)
+            return []
 
     run = None
     run_dir = None

--- a/src/databao_context_engine/build_sources/internal/build_wiring.py
+++ b/src/databao_context_engine/build_sources/internal/build_wiring.py
@@ -9,6 +9,7 @@ from databao_context_engine.llm.factory import (
 )
 from databao_context_engine.project.info import get_dce_version
 from databao_context_engine.project.layout import ensure_project_dir
+from databao_context_engine.project.types import DatasourceId
 from databao_context_engine.services.chunk_embedding_service import ChunkEmbeddingMode
 from databao_context_engine.services.factories import (
     create_build_service,
@@ -19,7 +20,9 @@ from databao_context_engine.system.properties import get_db_path
 logger = logging.getLogger(__name__)
 
 
-def build_all_datasources(project_dir: Path, chunk_embedding_mode: ChunkEmbeddingMode) -> list[BuildContextResult]:
+def build_all_datasources(
+    project_dir: Path, chunk_embedding_mode: ChunkEmbeddingMode, datasource_ids: list[DatasourceId] | None = None
+) -> list[BuildContextResult]:
     """
     Public build entrypoint
     - Instantiates the build service
@@ -49,4 +52,5 @@ def build_all_datasources(project_dir: Path, chunk_embedding_mode: ChunkEmbeddin
             build_service=build_service,
             project_id=str(dce_config.project_id),
             dce_version=get_dce_version(),
+            datasource_ids=datasource_ids,
         )

--- a/src/databao_context_engine/databao_context_project_manager.py
+++ b/src/databao_context_engine/databao_context_project_manager.py
@@ -33,8 +33,9 @@ class DatabaoContextProjectManager:
     def build_context(
         self, datasource_ids: list[DatasourceId] | None, chunk_embedding_mode: ChunkEmbeddingMode
     ) -> list[BuildContextResult]:
-        # TODO: Filter which datasources to build by datasource_ids
-        return build_all_datasources(project_dir=self.project_dir, chunk_embedding_mode=chunk_embedding_mode)
+        return build_all_datasources(
+            project_dir=self.project_dir, chunk_embedding_mode=chunk_embedding_mode, datasource_ids=datasource_ids
+        )
 
     def check_datasource_connection(
         self, datasource_ids: list[DatasourceId] | None

--- a/tests/test_databao_context_project_manager.py
+++ b/tests/test_databao_context_project_manager.py
@@ -50,9 +50,69 @@ def test_databao_context_project_manager__build_with_multiple_datasource(project
         datasource_type=DatasourceType(full_type="files/dummy"),
         file_content="Content of my dummy file",
     )
+    with_config_file(
+        project_dir=project_manager.project_dir,
+        full_type="dummy/dummy_default",
+        datasource_name="my_second_dummy_data",
+        config_content={"type": "dummy_default", "name": "my_second_dummy_data"},
+    )
 
     result = project_manager.build_context(
         datasource_ids=None, chunk_embedding_mode=ChunkEmbeddingMode.EMBEDDABLE_TEXT_ONLY
+    )
+
+    assert len(result) == 3
+    assert_build_context_result(
+        result[0],
+        project_manager.project_dir,
+        datasource_id=DatasourceId.from_string_repr("dummy/my_dummy_data.yaml"),
+        datasource_type=DatasourceType(full_type="dummy/dummy_default"),
+        context_file_relative_path="dummy/my_dummy_data.yaml",
+    )
+    assert_build_context_result(
+        result[1],
+        project_manager.project_dir,
+        datasource_id=DatasourceId.from_string_repr("dummy/my_second_dummy_data.yaml"),
+        datasource_type=DatasourceType(full_type="dummy/dummy_default"),
+        context_file_relative_path="dummy/my_second_dummy_data.yaml",
+    )
+    assert_build_context_result(
+        result[2],
+        project_manager.project_dir,
+        datasource_id=DatasourceId.from_string_repr("files/my_dummy_file.dummy"),
+        datasource_type=DatasourceType(full_type="files/dummy"),
+        context_file_relative_path="files/my_dummy_file.dummy.yaml",
+    )
+
+
+def test_databao_context_project_manager__build_custom_datasource_ids(project_path, create_db):
+    project_manager = DatabaoContextProjectManager(project_dir=project_path)
+
+    with_config_file(
+        project_dir=project_manager.project_dir,
+        full_type="dummy/dummy_default",
+        datasource_name="my_dummy_data",
+        config_content={"type": "dummy_default", "name": "my_dummy_data"},
+    )
+    with_config_file(
+        project_dir=project_manager.project_dir,
+        full_type="dummy/dummy_default",
+        datasource_name="my_second_dummy_data",
+        config_content={"type": "dummy_default", "name": "my_second_dummy_data"},
+    )
+    with_raw_source_file(
+        project_dir=project_manager.project_dir,
+        file_name="my_dummy_file",
+        datasource_type=DatasourceType(full_type="files/dummy"),
+        file_content="Content of my dummy file",
+    )
+
+    result = project_manager.build_context(
+        datasource_ids=[
+            DatasourceId.from_string_repr("files/my_dummy_file.dummy"),
+            DatasourceId.from_string_repr("dummy/my_dummy_data.yaml"),
+        ],
+        chunk_embedding_mode=ChunkEmbeddingMode.EMBEDDABLE_TEXT_ONLY,
     )
 
     assert len(result) == 2


### PR DESCRIPTION
# What?

This PR allows to filter which datasources to build when calling `DatabaoContextProjectManager.build_context`

# How?

The filtering was already done for the "check config" feature and we simply had to add it for the "build datasources" feature