### PR TITLE
Add new linters for our docstring

### DIFF
--- a/ruff.toml
+++ b/ruff.toml
@@ -2,3 +2,34 @@
 extend = "pyproject.toml"
 # But use a different line length.
 line-length = 120
+
+[lint]
+extend-select = [
+    # pydoclint
+    "DOC",
+    # pydocstyle
+    "D",
+]
+ignore = [
+    "D100",
+    "D101",
+    "D102",
+    "D103",
+    "D104",
+    "D105",
+    "D106",
+    "D107",
+]
+preview = true
+
+[lint.pydocstyle]
+# Use Google-style docstrings.
+convention = "google"
+
+[lint.pydoclint]
+# Skip docstrings which fit on a single line.
+ignore-one-line-docstrings = true
+
+[lint.per-file-ignores]
+# Ignore `D` and "DOC" rules everywhere except for the `src/` directory.
+"!src/**.py" = ["D", "DOC"]

--- a/src/databao_context_engine/build_sources/internal/build_runner.py
+++ b/src/databao_context_engine/build_sources/internal/build_runner.py
@@ -32,13 +32,18 @@ def build(
     project_id: str,
     dce_version: str,
 ) -> list[BuildContextResult]:
-    """
-    Build entrypoint.
+    """Build the context for all datasources in the project.
+
+    Unless you already have access to BuildService, this should not be called directly.
+    Instead, internal callers should go through the build_wiring module or directly use DatabaoContextProjectManager.build_context().
 
     1) Load available plugins
     2) Discover sources
     3) Create a run
     4) For each source, call process_source
+
+    Returns:
+        A list of all the contexts built.
     """
     plugins = load_plugins()
 

--- a/src/databao_context_engine/build_sources/internal/build_service.py
+++ b/src/databao_context_engine/build_sources/internal/build_service.py
@@ -30,15 +30,11 @@ class BuildService:
         self._chunk_embedding_service = chunk_embedding_service
 
     def start_run(self, *, project_id: str, dce_version: str) -> RunDTO:
-        """
-        Create a new run row and return (run_id, started_at).
-        """
+        """Create a new run row and return (run_id, started_at)."""
         return self._run_repo.create(project_id=project_id, dce_version=dce_version)
 
     def finalize_run(self, *, run_id: int):
-        """
-        Mark the run as complete (sets ended_at).
-        """
+        """Mark the run as complete (sets ended_at)."""
         self._run_repo.update(run_id=run_id, ended_at=datetime.now())
 
     def process_prepared_source(
@@ -48,12 +44,14 @@ class BuildService:
         prepared_source: PreparedDatasource,
         plugin: BuildPlugin,
     ) -> BuiltDatasourceContext:
-        """
-        Process a single source.
+        """Process a single source to build its context.
 
         1) Execute the plugin
         2) Divide the results into chunks
         3) Embed and persist the chunks
+
+        Returns:
+            The built context.
         """
         result = execute(prepared_source, plugin)
 

--- a/src/databao_context_engine/build_sources/internal/build_wiring.py
+++ b/src/databao_context_engine/build_sources/internal/build_wiring.py
@@ -20,10 +20,13 @@ logger = logging.getLogger(__name__)
 
 
 def build_all_datasources(project_dir: Path, chunk_embedding_mode: ChunkEmbeddingMode) -> list[BuildContextResult]:
-    """
-    Public build entrypoint
+    """Build the context for all datasources in the project.
+
     - Instantiates the build service
     - Delegates the actual build logic to the build runner
+
+    Returns:
+        A list of all the contexts built.
     """
     project_layout = ensure_project_dir(project_dir)
 

--- a/src/databao_context_engine/build_sources/internal/plugin_execution.py
+++ b/src/databao_context_engine/build_sources/internal/plugin_execution.py
@@ -13,9 +13,7 @@ from databao_context_engine.project.types import PreparedConfig, PreparedDatasou
 
 @dataclass()
 class BuiltDatasourceContext:
-    """
-    Dataclass defining the result of building a datasource's context.
-    """
+    """Dataclass defining the result of building a datasource's context."""
 
     datasource_id: str
     """
@@ -53,9 +51,7 @@ def execute(prepared_datasource: PreparedDatasource, plugin: BuildPlugin) -> Bui
 
 
 def _execute(prepared_datasource: PreparedDatasource, plugin: BuildPlugin) -> Any:
-    """
-    Run a prepared source through the plugin
-    """
+    """Run a prepared source through the plugin."""
     if isinstance(prepared_datasource, PreparedConfig):
         ds_plugin = cast(BuildDatasourcePlugin, plugin)
 

--- a/src/databao_context_engine/cli/commands.py
+++ b/src/databao_context_engine/cli/commands.py
@@ -55,19 +55,14 @@ def dce(ctx: Context, verbose: bool, quiet: bool, project_dir: str | None) -> No
 @dce.command()
 @click.pass_context
 def info(ctx: Context) -> None:
-    """
-    Display system-wide information
-    """
-
+    """Display system-wide information."""
     echo_info(ctx.obj["project_dir"])
 
 
 @dce.command()
 @click.pass_context
 def init(ctx: Context) -> None:
-    """
-    Create an empty Databao Context Engine project
-    """
+    """Create an empty Databao Context Engine project."""
     project_dir = ctx.obj["project_dir"]
     try:
         init_dce_project(project_dir=project_dir)
@@ -97,17 +92,14 @@ def init(ctx: Context) -> None:
 
 @dce.group()
 def datasource() -> None:
-    """
-    Manage datasource configurations
-    """
+    """Manage datasource configurations."""
     pass
 
 
 @datasource.command(name="add")
 @click.pass_context
 def add_datasource_config(ctx: Context) -> None:
-    """
-    Add a new datasource configuration.
+    """Add a new datasource configuration.
 
     The command will ask all relevant information for that datasource and save it in your Databao Context Engine project.
     """
@@ -122,15 +114,13 @@ def add_datasource_config(ctx: Context) -> None:
 )
 @click.pass_context
 def check_datasource_config(ctx: Context, datasources_config_files: list[str] | None) -> None:
-    """
-    Check whether a datasource configuration is valid.
+    """Check whether a datasource configuration is valid.
 
     The configuration is considered as valid if a connection with the datasource can be established.
 
     By default, all datasources declared in the project will be checked.
     You can explicitely list which datasources to validate by using the [DATASOURCES_CONFIG_FILES] argument. Each argument must be the path to the file within the src folder (e.g: my-folder/my-config.yaml)
     """
-
     datasource_ids = (
         [DatasourceId.from_string_repr(datasource_config_file) for datasource_config_file in datasources_config_files]
         if datasources_config_files is not None
@@ -157,8 +147,7 @@ def build(
         "embeddable_text_only", "generated_description_only", "embeddable_text_and_generated_description"
     ],
 ) -> None:
-    """
-    Build context for all datasources
+    """Build context for all datasources.
 
     The output of the build command will be saved in a "run" folder in the output directory.
 
@@ -204,9 +193,7 @@ def retrieve(
     limit: int | None,
     output_format: Literal["file", "streamed"],
 ) -> None:
-    """
-    Search the project's built context for the most relevant chunks.
-    """
+    """Search the project's built context for the most relevant chunks."""
     text = " ".join(retrieve_text)
 
     databao_engine = DatabaoContextEngine(project_dir=ctx.obj["project_dir"])
@@ -248,9 +235,7 @@ def retrieve(
 )
 @click.pass_context
 def mcp(ctx: Context, run_name: str | None, host: str | None, port: int | None, transport: McpTransport) -> None:
-    """
-    Run Databao Context Engine's MCP server
-    """
+    """Run Databao Context Engine's MCP server."""
     if transport == "stdio":
         configure_logging(verbose=False, quiet=True, project_dir=ctx.obj["project_dir"])
     run_mcp_server(project_dir=ctx.obj["project_dir"], run_name=run_name, transport=transport, host=host, port=port)

--- a/src/databao_context_engine/llm/errors.py
+++ b/src/databao_context_engine/llm/errors.py
@@ -3,14 +3,8 @@ class OllamaError(Exception):
 
 
 class OllamaTransientError(OllamaError):
-    """
-    Errors that are likely temporary (network issues, timeouts, 5xx, etc.).
-    Typically worth retrying.
-    """
+    """Errors that are likely temporary (network issues, timeouts, 5xx, etc.), typically worth retrying."""
 
 
 class OllamaPermanentError(OllamaError):
-    """
-    Errors that are unlikely to succeed on retry without changing inputs
-    or configuration (4xx, bad response schema, etc.).
-    """
+    """Errors that are unlikely to succeed on retry without changing inputs or configuration (4xx, bad response schema, etc.)."""

--- a/src/databao_context_engine/llm/install.py
+++ b/src/databao_context_engine/llm/install.py
@@ -49,14 +49,15 @@ ARTIFACTS: dict[str, ArtifactInfo] = {
 
 
 def resolve_ollama_bin() -> str:
-    """
-    Decide which `ollama` binary to use, in this order:
+    """Decide which `ollama` binary to use.
 
+    Here is the priority order:
     1. DCE_OLLAMA_BIN env var, if set and exists
     2. `ollama` found on PATH
     3. Managed installation under MANAGED_OLLAMA_BIN
 
-    Returns the full path to the binary
+    Returns:
+        The full path to the binary
     """
     override = os.environ.get("DCE_OLLAMA_BIN")
     if override:
@@ -76,9 +77,7 @@ def resolve_ollama_bin() -> str:
 
 
 def _detect_platform() -> str:
-    """
-    Return one of: 'darwin', 'linux-amd64', 'linux-arm64', 'windows-amd64', 'windows-arm64'.
-    """
+    """Return one of: 'darwin', 'linux-amd64', 'linux-arm64', 'windows-amd64', 'windows-arm64'."""
     os_name = sys.platform.lower()
     arch = (os.uname().machine if hasattr(os, "uname") else "").lower()
 
@@ -97,9 +96,7 @@ def _detect_platform() -> str:
 
 
 def _download_to_temp(url: str) -> Path:
-    """
-    Download to a temporary file and return its path.
-    """
+    """Download to a temporary file and return its path."""
     import urllib.request
 
     tmp_dir = Path(tempfile.mkdtemp(prefix="ollama-download-"))
@@ -114,9 +111,7 @@ def _download_to_temp(url: str) -> Path:
 
 
 def _verify_sha256(path: Path, expected_hex: str) -> None:
-    """
-    Verify SHA-256 of path matches expected_hex
-    """
+    """Verify SHA-256 of path matches expected_hex."""
     h = hashlib.sha256()
     with path.open("rb") as f:
         for chunk in iter(lambda: f.read(8192), b""):
@@ -127,9 +122,7 @@ def _verify_sha256(path: Path, expected_hex: str) -> None:
 
 
 def _extract_archive(archive: Path, target_dir: Path) -> None:
-    """
-    Extract archive into target_dir.
-    """
+    """Extract archive into target_dir."""
     name = archive.name.lower()
     target_dir.mkdir(parents=True, exist_ok=True)
 
@@ -144,9 +137,7 @@ def _extract_archive(archive: Path, target_dir: Path) -> None:
 
 
 def _ensure_executable(path: Path) -> None:
-    """
-    Mark path as executable
-    """
+    """Mark path as executable."""
     try:
         mode = path.stat().st_mode
         path.chmod(mode | stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH)
@@ -155,8 +146,7 @@ def _ensure_executable(path: Path) -> None:
 
 
 def install_ollama_to(target: Path) -> None:
-    """
-    Ensure an Ollama binary exists.
+    """Ensure an Ollama binary exist.
 
     If it doesn't exist, this will:
     - detect OS
@@ -164,6 +154,9 @@ def install_ollama_to(target: Path) -> None:
     - verify its SHA-256 checksum
     - extract into the installation directory
     - make the binary executable
+
+    Raises:
+        RuntimeError: If the user's platform is not supported
     """
     target = target.expanduser()
     if target.parent.name == "bin":

--- a/src/databao_context_engine/llm/service.py
+++ b/src/databao_context_engine/llm/service.py
@@ -36,9 +36,7 @@ class OllamaService:
         return [float(x) for x in vec]
 
     def describe(self, *, model: str, text: str, context: str) -> str:
-        """
-        Ask Ollama to generate a short description for `text`
-        """
+        """Ask Ollama to generate a short description for `text`."""
         prompt = self._build_description_prompt(text=text, context=context)
 
         payload: dict[str, Any] = {"model": model, "prompt": prompt, "stream": False, "options": {"temperature": 0.1}}

--- a/src/databao_context_engine/mcp/retrieve_tool.py
+++ b/src/databao_context_engine/mcp/retrieve_tool.py
@@ -6,11 +6,7 @@ from databao_context_engine import DatabaoContextEngine
 def run_retrieve_tool(
     *, databao_context_engine: DatabaoContextEngine, run_name: str | None, text: str, limit: int | None = None
 ) -> str:
-    """
-    Execute the retrieve flow for MCP and return the matching display texts
-    Adds the current date to the end
-    """
-
+    """Execute the retrieve flow for MCP and return the matching display texts."""
     retrieve_results = databao_context_engine.search_context(
         retrieve_text=text, run_name=run_name, limit=limit, export_to_file=False
     )

--- a/src/databao_context_engine/pluginlib/build_plugin.py
+++ b/src/databao_context_engine/pluginlib/build_plugin.py
@@ -5,9 +5,7 @@ from typing import Any, Protocol, runtime_checkable
 
 @dataclass
 class EmbeddableChunk:
-    """
-    A chunk that will be embedded as a vector and used when searching context from a given AI prompt
-    """
+    """A chunk that will be embedded as a vector and used when searching context from a given AI prompt."""
 
     embeddable_text: str
     """
@@ -48,19 +46,19 @@ class BuildDatasourcePlugin[T](BaseBuildPlugin, Protocol):
     """
 
     def check_connection(self, full_type: str, datasource_name: str, file_config: T) -> None:
-        """
-        Checks whether the configuration to the datasource is working.
+        """Check whether the configuration to the datasource is working.
 
         The function is expected to succeed without a result if the connection is working.
         If something is wrong with the connection, the function should raise an Exception
+
+        Raises:
+            NotSupportedError: If the plugin doesn't support this method.
         """
         raise NotSupportedError("This method is not implemented for this plugin")
 
 
 class DefaultBuildDatasourcePlugin(BuildDatasourcePlugin[dict[str, Any]], Protocol):
-    """
-    Use this as a base class for plugins that don't need a specific config file type.
-    """
+    """Use this as a base class for plugins that don't need a specific config file type."""
 
     config_file_type: type[dict[str, Any]] = dict[str, Any]
 
@@ -75,7 +73,7 @@ class BuildFilePlugin(BaseBuildPlugin, Protocol):
 
 
 class NotSupportedError(RuntimeError):
-    """Exception raised by methods not supported by a plugin"""
+    """Exception raised by methods not supported by a plugin."""
 
 
 BuildPlugin = BuildDatasourcePlugin | BuildFilePlugin

--- a/src/databao_context_engine/plugins/databases/base_introspector.py
+++ b/src/databao_context_engine/plugins/databases/base_introspector.py
@@ -121,9 +121,11 @@ class BaseIntrospector[T: SupportsIntrospectionScope](ABC):
 
     @abstractmethod
     def _connect_to_catalog(self, file_config: T, catalog: str):
-        """Return a connection scoped to `catalog`. For engines that
-        don’t need a new connection, return a connection with the
-        session set/USE’d to that catalog."""
+        """Return a connection scoped to `catalog`.
+
+        For engines that don’t need a new connection, return a connection with the
+        session set/USE’d to that catalog.
+        """
 
     def _sql_sample_rows(self, catalog: str, schema: str, table: str, limit: int) -> SQLQuery:
         raise NotImplementedError

--- a/src/databao_context_engine/plugins/databases/introspection_scope.py
+++ b/src/databao_context_engine/plugins/databases/introspection_scope.py
@@ -6,10 +6,11 @@ from pydantic import BaseModel, ConfigDict, field_validator, model_validator
 
 
 class ScopeIncludeRule(BaseModel):
-    """
-    Allowlist selector.
-    - catalog: optional glob pattern
-    - schemas: optional list of glob patterns (string also accepted and normalized to a list)
+    """Allowlist selector.
+
+    Attributes:
+        catalog: optional glob pattern
+        schemas: optional list of glob patterns (string also accepted and normalized to a list)
 
     A rule must specify at least one of: catalog, schemas.
     """
@@ -36,11 +37,12 @@ class ScopeIncludeRule(BaseModel):
 
 
 class ScopeExcludeRule(BaseModel):
-    """
-    Denylist selector.
-    - catalog: optional glob pattern
-    - schemas: optional list of glob patterns (string also accepted)
-    - except_schemas: optional list of glob patterns (string also accepted)
+    """Denylist selector.
+
+    Attributes:
+        catalog: optional glob pattern
+        schemas: optional list of glob patterns (string also accepted)
+        except_schemas: optional list of glob patterns (string also accepted)
 
     If a target matches the rule but also matches except_schemas, it is NOT excluded by this rule.
     """

--- a/src/databao_context_engine/plugins/databases/introspection_scope_matcher.py
+++ b/src/databao_context_engine/plugins/databases/introspection_scope_matcher.py
@@ -10,17 +10,14 @@ from databao_context_engine.plugins.databases.introspection_scope import (
 
 @dataclass(frozen=True)
 class ScopeSelection:
-    """
-    The final catalog+schema scope to introspect.
-    """
+    """The final catalog+schema scope to introspect."""
 
     catalogs: list[str]
     schemas_per_catalog: dict[str, list[str]]
 
 
 class IntrospectionScopeMatcher:
-    """
-    Applies include/exclude rules (glob matching, case-insensitive) to a discovered set of catalogs/schemas.
+    """Applies include/exclude rules (glob matching, case-insensitive) to a discovered set of catalogs/schemas.
 
     Semantics:
     - If include is empty => start from "everything"

--- a/src/databao_context_engine/plugins/plugin_loader.py
+++ b/src/databao_context_engine/plugins/plugin_loader.py
@@ -15,9 +15,7 @@ class DuplicatePluginTypeError(RuntimeError):
 
 
 def load_plugins(exclude_file_plugins: bool = False) -> dict[DatasourceType, BuildPlugin]:
-    """
-    Loads both builtin and external plugins and merges them into one list
-    """
+    """Load both builtin and external plugins and merges them into one list."""
     builtin_plugins = _load_builtin_plugins(exclude_file_plugins)
     external_plugins = _load_external_plugins(exclude_file_plugins)
     plugins = _merge_plugins(builtin_plugins, external_plugins)
@@ -45,9 +43,7 @@ def _load_builtin_file_plugins() -> list[BuildFilePlugin]:
 
 
 def _load_builtin_datasource_plugins() -> list[BuildDatasourcePlugin]:
-    """
-    Statically register built-in plugins
-    """
+    """Statically register built-in plugins."""
     from databao_context_engine.plugins.athena_db_plugin import AthenaDbPlugin
     from databao_context_engine.plugins.clickhouse_db_plugin import ClickhouseDbPlugin
     from databao_context_engine.plugins.duckdb_db_plugin import DuckDbPlugin
@@ -78,17 +74,13 @@ def _load_builtin_datasource_plugins() -> list[BuildDatasourcePlugin]:
 
 
 def _load_external_plugins(exclude_file_plugins: bool = False) -> list[BuildPlugin]:
-    """
-    Discover external plugins via entry points
-    """
+    """Discover external plugins via entry points."""
     # TODO: implement external plugin loading
     return []
 
 
 def _merge_plugins(*plugin_lists: list[BuildPlugin]) -> dict[DatasourceType, BuildPlugin]:
-    """
-    Merge multiple plugin maps
-    """
+    """Merge multiple plugin maps."""
     registry: dict[DatasourceType, BuildPlugin] = {}
     for plugins in plugin_lists:
         for plugin in plugins:

--- a/src/databao_context_engine/project/datasource_discovery.py
+++ b/src/databao_context_engine/project/datasource_discovery.py
@@ -41,13 +41,18 @@ def get_datasource_list(project_dir: Path) -> list[Datasource]:
 
 
 def discover_datasources(project_dir: Path) -> list[DatasourceDescriptor]:
-    """
-    Scan the project's src/ directory and return all discovered sources.
+    """Scan the project's src/ directory and return all discovered sources.
 
     Rules:
         - Each first-level directory under src/ is treated as a main_type
         - Unsupported or unreadable entries are skipped.
         - The returned list is sorted by directory and then filename
+
+    Returns:
+        A list of DatasourceDescriptor instances representing the discovered datasources.
+
+    Raises:
+        ValueError: If the src directory does not exist in the project directory.
     """
     src = get_source_dir(project_dir)
     if not src.exists() or not src.is_dir():
@@ -87,9 +92,7 @@ def get_datasource_descriptors(project_dir: Path, datasource_ids: list[Datasourc
 
 
 def load_datasource_descriptor(path: Path) -> DatasourceDescriptor | None:
-    """
-    Load a single file with src/<parent_name>/ into a DatasourceDescriptor
-    """
+    """Load a single file with src/<parent_name>/ into a DatasourceDescriptor."""
     if not path.is_file():
         return None
 
@@ -110,9 +113,7 @@ def load_datasource_descriptor(path: Path) -> DatasourceDescriptor | None:
 
 
 def prepare_source(datasource: DatasourceDescriptor) -> PreparedDatasource:
-    """
-    Convert a discovered datasource into a prepared datasource ready for plugin execution
-    """
+    """Convert a discovered datasource into a prepared datasource ready for plugin execution."""
     if datasource.kind is DatasourceKind.FILE:
         file_subtype = datasource.path.suffix.lower().lstrip(".")
         return PreparedFile(

--- a/src/databao_context_engine/project/types.py
+++ b/src/databao_context_engine/project/types.py
@@ -38,8 +38,7 @@ PreparedDatasource = PreparedConfig | PreparedFile
 
 @dataclass(kw_only=True, frozen=True, eq=True)
 class DatasourceId:
-    """
-    The ID of a datasource. The ID is the path to the datasource's config file relative to the src folder in the project.
+    """The ID of a datasource. The ID is the path to the datasource's config file relative to the src folder in the project.
 
     e.g: "databases/my_postgres_datasource.yaml"
 
@@ -78,16 +77,14 @@ class DatasourceId:
         return str(self.relative_path_to_config_file())
 
     def relative_path_to_config_file(self) -> Path:
-        """
-        Returns a path to the config file for this datasource.
+        """Return a path to the config file for this datasource.
 
         The returned path is relative to the src folder in the project.
         """
         return Path(self.datasource_config_folder).joinpath(self.datasource_name + self.config_file_suffix)
 
     def relative_path_to_context_file(self) -> Path:
-        """
-        Returns a path to the config file for this datasource.
+        """Return a path to the config file for this datasource.
 
         The returned path is relative to an output run folder in the project.
         """
@@ -97,13 +94,19 @@ class DatasourceId:
         return Path(self.datasource_config_folder).joinpath(self.datasource_name + suffix)
 
     @classmethod
-    def from_string_repr(cls, datasource_id_as_string: str):
-        """
-        Creates a DatasourceId from a string representation.
+    def from_string_repr(cls, datasource_id_as_string: str) -> "DatasourceId":
+        """Create a DatasourceId from a string representation.
 
-        The string representation of a DatasourceId is the path to the datasource's config file relative to the src folder in the project.
+        Args:
+            datasource_id_as_string: The string representation of a DatasourceId.
+                This is the path to the datasource's config file relative to the src folder in the project.
+                (e.g. "databases/my_postgres_datasource.yaml")
 
-        e.g: "databases/my_postgres_datasource.yaml"
+        Returns:
+            The DatasourceId instance created from the string representation.
+
+        Raises:
+            ValueError: If the string representation is invalid (e.g. too many parent folders).
         """
         config_file_path = Path(datasource_id_as_string)
 
@@ -115,11 +118,15 @@ class DatasourceId:
         return DatasourceId.from_datasource_config_file_path(config_file_path)
 
     @classmethod
-    def from_datasource_config_file_path(cls, datasource_config_file: Path):
-        """
-        Creates a DatasourceId from a config file path.
+    def from_datasource_config_file_path(cls, datasource_config_file: Path) -> "DatasourceId":
+        """Create a DatasourceId from a config file path.
 
-        The `datasource_config_file` path provided can either be the config file path relative to the src folder or the full path to the config file.
+        Args:
+            datasource_config_file: The path to the datasource config file.
+                This path can either be the config file path relative to the src folder or the full path to the config file.
+
+        Returns:
+            The DatasourceId instance created from the config file path.
         """
         return DatasourceId(
             datasource_config_folder=datasource_config_file.parent.name,
@@ -128,12 +135,17 @@ class DatasourceId:
         )
 
     @classmethod
-    def from_datasource_context_file_path(cls, datasource_context_file: Path):
-        """
-        Creates a DatasourceId from a context file path.
+    def from_datasource_context_file_path(cls, datasource_context_file: Path) -> "DatasourceId":
+        """Create a DatasourceId from a context file path.
 
         This factory handles the case where the context was generated from a raw file rather than from a config.
         In that case, the context file name will look like "<my_datasource_name>.<raw_file_extension>.yaml"
+
+        Args:
+            datasource_context_file: The path to the datasource context file.
+
+        Returns:
+            The DatasourceId instance created from the context file path.
         """
         if len(datasource_context_file.suffixes) > 1 and datasource_context_file.suffix == ".yaml":
             # If there is more than 1 suffix, we remove the latest suffix (.yaml) to keep only the actual datasource file suffix

--- a/src/databao_context_engine/services/chunk_embedding_service.py
+++ b/src/databao_context_engine/services/chunk_embedding_service.py
@@ -45,15 +45,13 @@ class ChunkEmbeddingService:
             raise ValueError("A DescriptionProvider must be provided when generating descriptions")
 
     def embed_chunks(self, *, datasource_run_id: int, chunks: list[EmbeddableChunk], result: str) -> None:
-        """
-        Turn plugin chunks into persisted chunks and embeddings
+        """Turn plugin chunks into persisted chunks and embeddings.
 
         Flow:
         1) Embed each chunk into an embedded vector
         2) Get or create embedding table for the appropriate model and embedding dimensions
         3) Persist chunks and embeddings vectors in a single transaction
         """
-
         if not chunks:
             return
 

--- a/src/databao_context_engine/services/persistence_service.py
+++ b/src/databao_context_engine/services/persistence_service.py
@@ -26,9 +26,11 @@ class PersistenceService:
     def write_chunks_and_embeddings(
         self, *, datasource_run_id: int, chunk_embeddings: list[ChunkEmbedding], table_name: str
     ):
-        """
-        Atomically persist chunks and their vectors.
-        Returns the number of embeddings written.
+        """Atomically persist chunks and their vectors.
+
+        Raises:
+            ValueError: If chunk_embeddings is an empty list.
+
         """
         if not chunk_embeddings:
             raise ValueError("chunk_embeddings must be a non-empty list")

--- a/src/databao_context_engine/storage/connection.py
+++ b/src/databao_context_engine/storage/connection.py
@@ -1,8 +1,10 @@
 import logging
 from contextlib import contextmanager
 from pathlib import Path
+from typing import Iterator
 
 import duckdb
+from _duckdb import DuckDBPyConnection
 
 from databao_context_engine.system.properties import get_db_path
 
@@ -10,13 +12,17 @@ logger = logging.getLogger(__name__)
 
 
 @contextmanager
-def open_duckdb_connection(db_path: str | Path | None = None):
-    """
-    Open a DuckDB connection with vector search enabled and close on exist.
-    Loads the vss extension and enables HNSW experimental persistence.
+def open_duckdb_connection(db_path: str | Path | None = None) -> Iterator[DuckDBPyConnection]:
+    """Open a DuckDB connection with vector search enabled and close on exist.
+
+    It also loads the vss extension and enables HNSW experimental persistence on the DuckDB.
 
     Usage:
         with open_duckdb_connection() as conn:
+
+    Yields:
+        The opened DuckDB connection.
+
     """
     path = str(db_path or get_db_path())
     conn = duckdb.connect(path)

--- a/src/databao_context_engine/storage/exceptions/exceptions.py
+++ b/src/databao_context_engine/storage/exceptions/exceptions.py
@@ -1,6 +1,6 @@
 class RepositoryError(Exception):
-    """Base exception for repository errors"""
+    """Base exception for repository errors."""
 
 
 class IntegrityError(RepositoryError):
-    """Raised when a DB constraint is violated"""
+    """Raised when a DB constraint is violated."""

--- a/src/databao_context_engine/storage/repositories/vector_search_repository.py
+++ b/src/databao_context_engine/storage/repositories/vector_search_repository.py
@@ -25,10 +25,7 @@ class VectorSearchRepository:
     def get_display_texts_by_similarity(
         self, *, table_name: str, run_id: int, retrieve_vec: Sequence[float], dimension: int, limit: int
     ) -> list[VectorSearchResult]:
-        """
-        Read only similarity search on a specific embedding shard table.
-        Returns the display text for the closest matches in a given run
-        """
+        """Read only similarity search on a specific embedding shard table."""
         rows = self._conn.execute(
             f"""
             SELECT

--- a/tests/integration/test_e2e_build.py
+++ b/tests/integration/test_e2e_build.py
@@ -71,8 +71,8 @@ def _force_test_db(monkeypatch, db_path: Path):
 
 @pytest.fixture
 def conn(db_path: Path):
-    """
-    Open a connection to the SAME db file the app will use (db_path).
+    """Open a connection to the SAME db file the app will use (db_path).
+
     Run migrations and load extensions so repo assertions work.
     """
     migrate(db_path)

--- a/tests/mcp/test_mcp_server.py
+++ b/tests/mcp/test_mcp_server.py
@@ -27,8 +27,7 @@ async def run_mcp_server_stdio_test(
     dce_path: Path,
     run_name: str | None = None,
 ):
-    """
-    Runs an MCP Server integration test by:
+    """Runs an MCP Server integration test by:
     1. Spawning a new process to run the MCP server in stdio mode
     2. Creating a client connecting with the MCP Server
     3. Yielding the MCP client session for the test to run
@@ -58,8 +57,7 @@ async def run_mcp_server_http_test(
     host: str | None = None,
     port: int | None = None,
 ):
-    """
-    Runs a MCP Server integration test by:
+    """Runs a MCP Server integration test by:
     1. Spawning a new process to run the MCP server in streamable-http mode
     2. Creating a client connecting with the MCP Server (we're retrying 5 times to wait for the server to be up and running)
     3. Yielding the MCP client session for the test to run


### PR DESCRIPTION
# What?

In the context of the repository being public, we want the documentation on our public classes to follow a consistent style and to be up-to-date with the actual function signature.

This PR adds two linters that will make sure of that: pydoclint and pydocstyle.

# How?

I've introduced the two linters in Ruff so that we don't need to change our CI or pre-commit.

The pydocstyle is using the "google" convention as its rule to describe a function or class (see [examples here](https://sphinxcontrib-napoleon.readthedocs.io/en/latest/example_google.html)).

The rules are only applied within our `src` directory (which means that tests don't need to follow those rules).

For now, I've excluded some rules that make sure that all public APIs are documented: I'll start adding docstring on all of our public APIs and we should be able to remove those exclusions once we've documented everything

# Consequences

After merging this PR, whenever we add a docstring, even on private APIs, we will now to either:
- keep the docstring on one-line (we have an exception in the linter telling it that one-liner don't need to specify all arguments, return values, etc.)
- follow a strict format for the docstring, documenting properly the function, with its return value