### PR TITLE
NEM-309: Handle ForwardRef and str types when extracting the properties of a config file

### DIFF
--- a/src/databao_context_engine/introspection/property_extract.py
+++ b/src/databao_context_engine/introspection/property_extract.py
@@ -2,7 +2,7 @@ import types
 from dataclasses import MISSING, fields, is_dataclass
 from typing import Annotated, Any, ForwardRef, Union, get_args, get_origin, get_type_hints
 
-from pydantic import BaseModel, _internal
+from pydantic import BaseModel
 from pydantic_core import PydanticUndefinedType
 
 from databao_context_engine.pluginlib.config import (
@@ -59,18 +59,14 @@ def _get_property_list_from_dataclass(parent_type: type) -> list[ConfigPropertyD
         raise ValueError(f"{parent_type} is not a dataclass")
 
     dataclass_fields = fields(parent_type)
+    type_hints = get_type_hints(parent_type, include_extras=True)
 
     result = []
     for field in dataclass_fields:
         has_field_default = field.default is not None and field.default != MISSING
 
-        if isinstance(field.type, str):
-            try:
-                property_type = _evaluate_type_string(field.type)
-            except Exception:
-                continue
-        else:
-            property_type = field.type
+        # Use the type hints if the field type wasn't resolved (aka. if it is a ForwardRef or a str)
+        property_type = type_hints[field.name] if isinstance(field.type, ForwardRef | str) else field.type
 
         property_for_field = _create_property(
             property_type=property_type,
@@ -88,6 +84,10 @@ def _get_property_list_from_dataclass(parent_type: type) -> list[ConfigPropertyD
 def _get_property_list_from_pydantic_base_model(parent_type: type):
     if not issubclass(parent_type, BaseModel):
         raise ValueError(f"{parent_type} is not a Pydantic BaseModel")
+
+    if any(isinstance(field.annotation, ForwardRef) for field in parent_type.model_fields.values()):
+        # If any field's future type wasn't resolved yet, we rebuild the model to resolve them
+        parent_type.model_rebuild(force=True)
 
     pydantic_fields = parent_type.model_fields
     result = []
@@ -214,18 +214,3 @@ def compute_default_value(
         return str(property_default)
 
     return None
-
-
-def _evaluate_type_string(property_type: str) -> type:
-    try:
-        # Using a pydantic internal function for this, to avoid having to implement type evaluation manually...
-        return _internal._typing_extra.eval_type(property_type)
-    except Exception as initial_error:
-        try:
-            # Try to convert it ourselves if Pydantic didn't work
-            return ForwardRef(property_type)._evaluate(  # type: ignore[return-value]
-                globalns=globals(), localns=locals(), recursive_guard=frozenset()
-            )
-        except Exception as e:
-            # Ignore if we didn't manage to convert the str to a type
-            raise e from initial_error

--- a/tests/introspection/test_property_extract.py
+++ b/tests/introspection/test_property_extract.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from dataclasses import dataclass, field
 from datetime import date, datetime
 from typing import Annotated, Any, Collection, Mapping, Optional, TypedDict
@@ -64,8 +66,6 @@ def test_get_property_list_from_type__with_dataclass():
     property_list = get_property_list_from_type(TestDataclass)
 
     assert property_list == unordered(
-        ConfigSinglePropertyDefinition(property_key="a", required=False, property_type=int, default_value="1"),
-        ConfigSinglePropertyDefinition(property_key="b", required=False, property_type=float, default_value="3.14"),
         ConfigSinglePropertyDefinition(
             property_key="complex",
             required=True,
@@ -120,6 +120,8 @@ def test_get_property_list_from_type__with_dataclass():
                 ),
             ],
         ),
+        ConfigSinglePropertyDefinition(property_key="a", required=False, property_type=int, default_value="1"),
+        ConfigSinglePropertyDefinition(property_key="b", required=False, property_type=float, default_value="3.14"),
     )
 
 
@@ -146,6 +148,12 @@ class DataclassWithAllCases:
     ] = field(default=False)
     property_with_string_type: "str"
     property_with_union_type_as_string: "int | None"
+    property_with_future_type: NestedDataclassModel
+    property_with_future_type_and_annotation: Annotated[NestedDataclassModel, ConfigPropertyAnnotation(required=False)]
+
+
+class NestedDataclassModel(BaseModel):
+    one_property: str
 
 
 def test_get_property_list__from_dataclass():
@@ -183,6 +191,22 @@ def test_get_property_list__from_dataclass():
                 required=True,
                 property_type=int,
             ),
+            ConfigSinglePropertyDefinition(
+                property_key="property_with_future_type",
+                required=True,
+                property_type=None,
+                nested_properties=[
+                    ConfigSinglePropertyDefinition(property_key="one_property", required=True, property_type=str)
+                ],
+            ),
+            ConfigSinglePropertyDefinition(
+                property_key="property_with_future_type_and_annotation",
+                required=False,
+                property_type=None,
+                nested_properties=[
+                    ConfigSinglePropertyDefinition(property_key="one_property", required=True, property_type=str)
+                ],
+            ),
         ]
     )
 
@@ -199,6 +223,12 @@ class BaseModelWithAllCases(BaseModel):
     )
     property_with_string_type: "str"
     property_with_union_type_as_string: "float | None"
+    property_with_future_type: NestedPydanticModel
+    property_with_future_type_and_annotation: Annotated[NestedPydanticModel, ConfigPropertyAnnotation(required=False)]
+
+
+class NestedPydanticModel(BaseModel):
+    one_property: str
 
 
 def test_get_property_list__from_pydantic_base_model():
@@ -242,6 +272,22 @@ def test_get_property_list__from_pydantic_base_model():
                 property_key="property_with_union_type_as_string",
                 required=True,
                 property_type=float,
+            ),
+            ConfigSinglePropertyDefinition(
+                property_key="property_with_future_type",
+                required=True,
+                property_type=None,
+                nested_properties=[
+                    ConfigSinglePropertyDefinition(property_key="one_property", required=True, property_type=str)
+                ],
+            ),
+            ConfigSinglePropertyDefinition(
+                property_key="property_with_future_type_and_annotation",
+                required=False,
+                property_type=None,
+                nested_properties=[
+                    ConfigSinglePropertyDefinition(property_key="one_property", required=True, property_type=str)
+                ],
             ),
         ]
     )


### PR DESCRIPTION
#What?

Our property extract function was trying to handle types given as strings (e.g: `my_field: "MyType"`) but it was breaking when instead the type was defined using the `from __future__ import annotations` import (which automatically replaces all types to a str).

# How?

There are 3 cases we support:
### 1. "regular" classes

This was working fine as `get_type_hints(parent_type, include_extras=True)` natively converts str and ForwardRef

### 2. dataclasses

We were previously trying to handle "str" types by evaluating them manually, which was failing when using future annotations.
Instead we are now relying on `get_type_hints(parent_type, include_extras=True)` to get the actual type of the field (while still using the other information we can get from the dataclass).

### 3. Pydantic models

"str" types were handled by default by Pydantic. However, when using future annotations, by default, the Pydantic model was creating a `ForwardRef` for all types that couldn't be resolved when the class was loaded.

Fortunately, Pydantic provides a helper method to "rebuild" the schema of the model at runtime (when in theory all required classes should have loaded). We're now calling this rebuild when we detect that some of the types have not been resolved in the model.

# Benefits

With this PR, we actually removed the reliance on internal Pydantics function, to instead use the native `get_type_hints` when needed.

# DuckDB example

The previously broken DuckDB config is now properly asking for the database path:
<img width="992" height="208" alt="Screenshot 2026-01-27 at 14 26 35" src="https://github.com/user-attachments/assets/02b128a3-a64c-4551-8bfc-bee1cb7bff98" />
