### PR TITLE
[Ruff] Enable the RET ruff rules and fix all existing violations

### DIFF
--- a/ruff.toml
+++ b/ruff.toml
@@ -12,6 +12,7 @@ extend-select = [
     "I",
     "T20",
     "S",
+    "RET",
 ]
 ignore = [
     "D100",

--- a/src/databao_context_engine/build_sources/plugin_execution.py
+++ b/src/databao_context_engine/build_sources/plugin_execution.py
@@ -61,10 +61,10 @@ def _execute(prepared_datasource: PreparedDatasource, plugin: BuildPlugin) -> An
             config=prepared_datasource.config,
             datasource_name=prepared_datasource.datasource_name,
         )
-    else:
-        file_plugin = cast(BuildFilePlugin, plugin)
-        return execute_file_plugin(
-            plugin=file_plugin,
-            datasource_type=prepared_datasource.datasource_type,
-            file_path=prepared_datasource.path,
-        )
+
+    file_plugin = cast(BuildFilePlugin, plugin)
+    return execute_file_plugin(
+        plugin=file_plugin,
+        datasource_type=prepared_datasource.datasource_type,
+        file_path=prepared_datasource.path,
+    )

--- a/src/databao_context_engine/databao_context_engine.py
+++ b/src/databao_context_engine/databao_context_engine.py
@@ -88,11 +88,9 @@ class DatabaoContextEngine:
     def get_all_contexts_formatted(self) -> str:
         all_contexts = self.get_all_contexts()
 
-        all_results = os.linesep.join(
+        return os.linesep.join(
             [f"{get_context_header_for_datasource(context.datasource_id)}{context.context}" for context in all_contexts]
         )
-
-        return all_results
 
     def search_context(
         self,

--- a/src/databao_context_engine/datasources/check_config.py
+++ b/src/databao_context_engine/datasources/check_config.py
@@ -127,16 +127,16 @@ def _get_validation_result_from_error(datasource_id: DatasourceId, e: Exception)
             summary="Config file is invalid",
             full_message=str(e),
         )
-    elif isinstance(e, NotImplementedError | NotSupportedError):
+    if isinstance(e, NotImplementedError | NotSupportedError):
         return CheckDatasourceConnectionResult(
             datasource_id=datasource_id,
             connection_status=DatasourceConnectionStatus.UNKNOWN,
             summary="Plugin doesn't support validating its config",
         )
-    else:
-        return CheckDatasourceConnectionResult(
-            datasource_id=datasource_id,
-            connection_status=DatasourceConnectionStatus.INVALID,
-            summary="Connection with the datasource can not be established",
-            full_message=str(e),
-        )
+
+    return CheckDatasourceConnectionResult(
+        datasource_id=datasource_id,
+        connection_status=DatasourceConnectionStatus.INVALID,
+        summary="Connection with the datasource can not be established",
+        full_message=str(e),
+    )

--- a/src/databao_context_engine/datasources/datasource_discovery.py
+++ b/src/databao_context_engine/datasources/datasource_discovery.py
@@ -121,19 +121,18 @@ def prepare_source(datasource: DatasourceDescriptor) -> PreparedDatasource:
             path=datasource.path,
         )
 
-    else:
-        config = _parse_config_file(datasource.path)
+    config = _parse_config_file(datasource.path)
 
-        subtype = config.get("type")
-        if not subtype or not isinstance(subtype, str):
-            raise ValueError("Config missing 'type' at %s - skipping", datasource.path)
+    subtype = config.get("type")
+    if not subtype or not isinstance(subtype, str):
+        raise ValueError("Config missing 'type' at %s - skipping", datasource.path)
 
-        return PreparedConfig(
-            datasource_type=DatasourceType.from_main_and_subtypes(main_type=datasource.main_type, subtype=subtype),
-            path=datasource.path,
-            config=config,
-            datasource_name=datasource.path.stem,
-        )
+    return PreparedConfig(
+        datasource_type=DatasourceType.from_main_and_subtypes(main_type=datasource.main_type, subtype=subtype),
+        path=datasource.path,
+        config=config,
+        datasource_name=datasource.path.stem,
+    )
 
 
 def _parse_config_file(file_path: Path) -> dict[Any, Any]:

--- a/src/databao_context_engine/generate_configs_schemas.py
+++ b/src/databao_context_engine/generate_configs_schemas.py
@@ -54,10 +54,9 @@ def _generate_json_schema_output_for_plugins(
     if len(filtered_plugins) == 0:
         if include_plugins:
             raise ValueError(f"No plugin found with id in {include_plugins}")
-        elif exclude_plugins:
+        if exclude_plugins:
             raise ValueError(f"No plugin found when excluding {exclude_plugins}")
-        else:
-            raise ValueError("No plugin found")
+        raise ValueError("No plugin found")
 
     results = []
     for plugin in filtered_plugins:

--- a/src/databao_context_engine/llm/descriptions/ollama.py
+++ b/src/databao_context_engine/llm/descriptions/ollama.py
@@ -16,6 +16,4 @@ class OllamaDescriptionProvider(DescriptionProvider):
         return self._model_id
 
     def describe(self, text: str, context: str) -> str:
-        description = self._service.describe(model=self._model_id, text=text, context=context)
-
-        return description
+        return self._service.describe(model=self._model_id, text=text, context=context)

--- a/src/databao_context_engine/llm/runtime.py
+++ b/src/databao_context_engine/llm/runtime.py
@@ -26,7 +26,7 @@ class OllamaRuntime:
 
         stdout = subprocess.DEVNULL
 
-        proc = subprocess.Popen(  # noqa: S603 We're always running Ollama
+        return subprocess.Popen(  # noqa: S603 We're always running Ollama
             cmd,
             cwd=str(self._config.work_dir) if self._config.work_dir else None,
             env=env,
@@ -35,8 +35,6 @@ class OllamaRuntime:
             text=False,
             close_fds=os.name != "nt",
         )
-
-        return proc
 
     def start_and_await(
         self,

--- a/src/databao_context_engine/plugin_loader.py
+++ b/src/databao_context_engine/plugin_loader.py
@@ -38,8 +38,8 @@ class DatabaoContextPluginLoader:
                 for (datasource_type, plugin) in self._all_plugins_by_type.items()
                 if not isinstance(plugin, BuildFilePlugin)
             }
-        else:
-            return set(self._all_plugins_by_type.keys())
+
+        return set(self._all_plugins_by_type.keys())
 
     def get_plugin_for_datasource_type(self, datasource_type: DatasourceType) -> BuildPlugin:
         """Return the plugin able to build a context for the given datasource type.
@@ -103,9 +103,8 @@ class DatabaoContextPluginLoader:
 
         if isinstance(plugin, CustomiseConfigProperties):
             return plugin.get_config_file_properties()
-        elif isinstance(plugin, BuildDatasourcePlugin):
+        if isinstance(plugin, BuildDatasourcePlugin):
             return get_property_list_from_type(plugin.config_file_type)
-        else:
-            raise ValueError(
-                f'Impossible to create a config for datasource type "{datasource_type.full_type}". The corresponding plugin is a {type(plugin).__name__} but should be a BuildDatasourcePlugin or CustomiseConfigProperties'
-            )
+        raise ValueError(
+            f'Impossible to create a config for datasource type "{datasource_type.full_type}". The corresponding plugin is a {type(plugin).__name__} but should be a BuildDatasourcePlugin or CustomiseConfigProperties'
+        )

--- a/src/databao_context_engine/plugins/databases/base_db_plugin.py
+++ b/src/databao_context_engine/plugins/databases/base_db_plugin.py
@@ -37,9 +37,7 @@ class BaseDatabasePlugin(BuildDatasourcePlugin[T]):
         return self.supported
 
     def build_context(self, full_type: str, datasource_name: str, file_config: T) -> Any:
-        introspection_result = self._introspector.introspect_database(file_config)
-
-        return introspection_result
+        return self._introspector.introspect_database(file_config)
 
     def check_connection(self, full_type: str, datasource_name: str, file_config: T) -> None:
         self._introspector.check_connection(file_config)

--- a/src/databao_context_engine/plugins/databases/base_introspector.py
+++ b/src/databao_context_engine/plugins/databases/base_introspector.py
@@ -74,9 +74,9 @@ class BaseIntrospector[T: SupportsIntrospectionScope](ABC):
         if self.supports_catalogs:
             sql = "SELECT catalog_name, schema_name FROM information_schema.schemata WHERE catalog_name = ANY(%s)"
             return SQLQuery(sql, (catalogs,))
-        else:
-            sql = "SELECT schema_name FROM information_schema.schemata"
-            return SQLQuery(sql, None)
+
+        sql = "SELECT schema_name FROM information_schema.schemata"
+        return SQLQuery(sql, None)
 
     def _list_schemas_for_catalog(self, connection: Any, catalog: str) -> list[str]:
         sql_query = self._sql_list_schemas([catalog] if self.supports_catalogs else None)

--- a/src/databao_context_engine/plugins/databases/mssql/mssql_introspector.py
+++ b/src/databao_context_engine/plugins/databases/mssql/mssql_introspector.py
@@ -422,8 +422,7 @@ class MSSQLIntrospector(BaseIntrospector[MSSQLConfigFile]):
             "trust_server_certificate": "yes" if file_config.get("trust_server_certificate") else None,
         }
 
-        connection_string = ";".join(f"{k}={v}" for k, v in connection_parts.items() if v is not None)
-        return connection_string
+        return ";".join(f"{k}={v}" for k, v in connection_parts.items() if v is not None)
 
     def _fetchall_dicts(self, connection, sql: str, params) -> list[dict]:
         with connection.cursor() as cursor:

--- a/src/databao_context_engine/plugins/databases/postgresql/postgresql_introspector.py
+++ b/src/databao_context_engine/plugins/databases/postgresql/postgresql_introspector.py
@@ -81,9 +81,9 @@ class PostgresqlIntrospector(BaseIntrospector[PostgresConfigFile]):
         if self.supports_catalogs:
             sql = "SELECT catalog_name, schema_name FROM information_schema.schemata WHERE catalog_name = ANY($1)"
             return SQLQuery(sql, (catalogs,))
-        else:
-            sql = "SELECT schema_name FROM information_schema.schemata"
-            return SQLQuery(sql, None)
+
+        sql = "SELECT schema_name FROM information_schema.schemata"
+        return SQLQuery(sql, None)
 
     def _connect(self, file_config: PostgresConfigFile):
         kwargs = self._create_connection_kwargs(file_config.connection)
@@ -97,8 +97,7 @@ class PostgresqlIntrospector(BaseIntrospector[PostgresConfigFile]):
         if database is not None:
             return [database]
 
-        rows = connection.fetch_scalar_values("SELECT datname FROM pg_catalog.pg_database WHERE datistemplate = false")
-        return rows
+        return connection.fetch_scalar_values("SELECT datname FROM pg_catalog.pg_database WHERE datistemplate = false")
 
     def _connect_to_catalog(self, file_config: PostgresConfigFile, catalog: str):
         cfg = file_config.model_copy(deep=True)
@@ -408,10 +407,7 @@ class PostgresqlIntrospector(BaseIntrospector[PostgresConfigFile]):
         }
         connection_parts.update(connection_config.additional_properties)
 
-        connection_string = " ".join(
-            f"{k}={_escape_pg_value(str(v))}" for k, v in connection_parts.items() if v is not None
-        )
-        return connection_string
+        return " ".join(f"{k}={_escape_pg_value(str(v))}" for k, v in connection_parts.items() if v is not None)
 
     def _create_connection_kwargs(self, connection_config: PostgresConnectionProperties) -> dict[str, Any]:
         kwargs: dict[str, Any] = {

--- a/src/databao_context_engine/plugins/plugin_loader.py
+++ b/src/databao_context_engine/plugins/plugin_loader.py
@@ -18,9 +18,8 @@ def load_plugins(exclude_file_plugins: bool = False) -> dict[DatasourceType, Bui
     """Load both builtin and external plugins and merges them into one list."""
     builtin_plugins = _load_builtin_plugins(exclude_file_plugins)
     external_plugins = _load_external_plugins(exclude_file_plugins)
-    plugins = _merge_plugins(builtin_plugins, external_plugins)
 
-    return plugins
+    return _merge_plugins(builtin_plugins, external_plugins)
 
 
 def _load_builtin_plugins(exclude_file_plugins: bool = False) -> list[BuildPlugin]:

--- a/src/databao_context_engine/plugins/resources/parquet_plugin.py
+++ b/src/databao_context_engine/plugins/resources/parquet_plugin.py
@@ -24,9 +24,7 @@ class ParquetPlugin(BuildDatasourcePlugin[ParquetConfigFile]):
         return build_parquet_chunks(context)
 
     def build_context(self, full_type: str, datasource_name: str, file_config: ParquetConfigFile) -> Any:
-        introspection_result = self._introspector.introspect(file_config)
-
-        return introspection_result
+        return self._introspector.introspect(file_config)
 
     def check_connection(self, full_type: str, datasource_name: str, file_config: ParquetConfigFile) -> None:
         self._introspector.check_connection(file_config)

--- a/src/databao_context_engine/serialization/yaml.py
+++ b/src/databao_context_engine/serialization/yaml.py
@@ -7,16 +7,16 @@ from yaml import Node, SafeDumper
 def default_representer(dumper: SafeDumper, data: object) -> Node:
     if isinstance(data, Mapping):
         return dumper.represent_dict(data)
-    elif hasattr(data, "__dict__"):
+    if hasattr(data, "__dict__"):
         # Doesn't serialize "private" attributes (that starts with an _)
         data_public_attributes = {key: value for key, value in data.__dict__.items() if not key.startswith("_")}
         if data_public_attributes:
             return dumper.represent_dict(data_public_attributes)
-        else:
-            # If there is no public attributes, we default to the string representation
-            return dumper.represent_str(str(data))
-    else:
+
+        # If there is no public attributes, we default to the string representation
         return dumper.represent_str(str(data))
+
+    return dumper.represent_str(str(data))
 
 
 # Registers our default representer only once, when that file is imported

--- a/tests/build_sources/test_build_runner.py
+++ b/tests/build_sources/test_build_runner.py
@@ -22,8 +22,7 @@ def _result(name="files/demo.md", typ="files/md"):
 
 @pytest.fixture
 def mock_build_service(mocker):
-    svc = mocker.Mock(name="BuildService")
-    return svc
+    return mocker.Mock(name="BuildService")
 
 
 @pytest.fixture

--- a/tests/llm/test_service.py
+++ b/tests/llm/test_service.py
@@ -304,10 +304,9 @@ class _StubSession:
         method = method.upper()
         if method == "POST":
             return self.post(url, **kwargs)
-        elif method == "GET":
+        if method == "GET":
             return self.get(url, **kwargs)
-        else:
-            raise ValueError(f"Unsupported method in _StubSession: {method}")
+        raise ValueError(f"Unsupported method in _StubSession: {method}")
 
 
 _LIST_MODELS_JSON_RESPONSE_WITH_NOMIC_MODEL = {

--- a/tests/plugins/test_plugin_loader.py
+++ b/tests/plugins/test_plugin_loader.py
@@ -97,4 +97,4 @@ def load_plugin_ids(*uv_extra_args) -> list[str]:
 """
     output = "".join(lines)
     plugin_ids = eval(output)
-    return plugin_ids
+    return plugin_ids  # noqa: RET504


### PR DESCRIPTION
# What?

This PR enables the RET ruff rules, that add linting rules around return values (see https://pypi.org/project/flake8-return/)

# How?

Most existing violations were around early returns that don't require an `else` or unnecessary variable assignment before a return. And they've mostly been fixed automatically via `uv run ruff check --fix`