### PR TITLE
[Ruff] Enable security ruff rules ("S")

### DIFF
--- a/ruff.toml
+++ b/ruff.toml
@@ -11,6 +11,7 @@ extend-select = [
     "D",
     "I",
     "T20",
+    "S",
 ]
 ignore = [
     "D100",
@@ -21,6 +22,8 @@ ignore = [
     "D105",
     "D106",
     "D107",
+    "S404", # excluded because there is other subchecks on the usage of subprocess
+    "S608", # excluded because we're builidng a lot of SQL queries using formatted strings for reusability (without using user input variables)
 ]
 preview = true
 
@@ -34,4 +37,4 @@ ignore-one-line-docstrings = true
 
 [lint.per-file-ignores]
 # Ignore `D` and "DOC" rules everywhere except for the `src/` directory.
-"!src/**.py" = ["D", "DOC", "T20"]
+"!src/**.py" = ["D", "DOC", "T20", "S"]

--- a/src/databao_context_engine/llm/runtime.py
+++ b/src/databao_context_engine/llm/runtime.py
@@ -26,7 +26,7 @@ class OllamaRuntime:
 
         stdout = subprocess.DEVNULL
 
-        proc = subprocess.Popen(
+        proc = subprocess.Popen(  # noqa: S603 We're always running Ollama
             cmd,
             cwd=str(self._config.work_dir) if self._config.work_dir else None,
             env=env,
@@ -62,11 +62,11 @@ class OllamaRuntime:
             try:
                 proc.terminate()
             except Exception:
-                pass
+                logger.debug("Failed to terminate Ollama server", exc_info=True, stack_info=True)
             try:
                 proc.kill()
             except Exception:
-                pass
+                logger.debug("Failed to kill Ollama server", exc_info=True, stack_info=True)
 
         raise TimeoutError(
             f"Timed out waiting for Ollama to become healthy at http://{self._config.host}:{self._config.port}"

--- a/src/databao_context_engine/storage/migrate.py
+++ b/src/databao_context_engine/storage/migrate.py
@@ -69,7 +69,7 @@ class _Migration:
 def _create_migration(file: Path) -> _Migration:
     query_bytes = file.read_bytes()
     query = query_bytes.decode("utf-8")
-    checksum = hashlib.md5(query_bytes).hexdigest()
+    checksum = hashlib.md5(query_bytes, usedforsecurity=False).hexdigest()
     version = _extract_version_from_name(file.name)
     return _Migration(name=file.name, version=version, checksum=checksum, query=query)
 


### PR DESCRIPTION
# What?

This PR enables the S ruff rules, that add linting rules checking the security of our code.

This is reproducing https://pypi.org/project/flake8-bandit

# How?

I had to exclude "S608" that checks that SQL query strings should be static because we are creating a lot of SQL queries using formatted strings.
This might be something we want to look into at some point, although I think most of them should be harmless as we are using internal variables to create the string rather than any user input.