### PR TITLE
[Config Files] Add variables in the Jinja templates to easily create relative path to files

### DIFF
--- a/src/databao_context_engine/build_sources/build_runner.py
+++ b/src/databao_context_engine/build_sources/build_runner.py
@@ -66,7 +66,7 @@ def build(
     reset_all_results(project_layout.output_dir)
     for discovered_datasource in datasources:
         try:
-            prepared_source = prepare_source(discovered_datasource)
+            prepared_source = prepare_source(project_layout, discovered_datasource)
 
             logger.info(
                 f'Found datasource of type "{prepared_source.datasource_type.full_type}" with name {prepared_source.path.stem}'

--- a/src/databao_context_engine/datasources/check_config.py
+++ b/src/databao_context_engine/datasources/check_config.py
@@ -69,7 +69,7 @@ def check_datasource_connection(
         result_key = DatasourceId.from_datasource_config_file_path(project_layout, discovered_datasource.path)
 
         try:
-            prepared_source = prepare_source(discovered_datasource)
+            prepared_source = prepare_source(project_layout, discovered_datasource)
         except Exception as e:
             result[result_key] = CheckDatasourceConnectionResult(
                 datasource_id=result_key,

--- a/src/databao_context_engine/datasources/datasource_discovery.py
+++ b/src/databao_context_engine/datasources/datasource_discovery.py
@@ -25,7 +25,7 @@ def get_datasource_list(project_layout: ProjectLayout) -> list[Datasource]:
     result = []
     for discovered_datasource in discover_datasources(project_layout=project_layout):
         try:
-            prepared_source = prepare_source(discovered_datasource)
+            prepared_source = prepare_source(project_layout, discovered_datasource)
         except Exception as e:
             logger.debug(str(e), exc_info=True, stack_info=True)
             logger.info(f"Invalid source at ({discovered_datasource.path}): {str(e)}")
@@ -112,7 +112,7 @@ def _load_datasource_descriptor(project_layout: ProjectLayout, config_file: Path
     return None
 
 
-def prepare_source(datasource: DatasourceDescriptor) -> PreparedDatasource:
+def prepare_source(project_layout: ProjectLayout, datasource: DatasourceDescriptor) -> PreparedDatasource:
     """Convert a discovered datasource into a prepared datasource ready for plugin execution."""
     if datasource.kind is DatasourceKind.FILE:
         file_subtype = datasource.path.suffix.lower().lstrip(".")
@@ -122,7 +122,7 @@ def prepare_source(datasource: DatasourceDescriptor) -> PreparedDatasource:
             path=datasource.path,
         )
 
-    config = _parse_config_file(datasource.path)
+    config = _parse_config_file(project_layout, datasource.path)
 
     ds_type = config.get("type")
     if not ds_type or not isinstance(ds_type, str):
@@ -137,7 +137,7 @@ def prepare_source(datasource: DatasourceDescriptor) -> PreparedDatasource:
     )
 
 
-def _parse_config_file(file_path: Path) -> dict[Any, Any]:
-    rendered_file = render_template(file_path.read_text())
+def _parse_config_file(project_layout: ProjectLayout, file_path: Path) -> dict[Any, Any]:
+    rendered_file = render_template(project_layout, file_path.read_text())
 
     return yaml.safe_load(rendered_file) or {}

--- a/src/databao_context_engine/templating/renderer.py
+++ b/src/databao_context_engine/templating/renderer.py
@@ -2,6 +2,8 @@ import os
 
 from jinja2.sandbox import SandboxedEnvironment
 
+from databao_context_engine.project.layout import ProjectLayout
+
 
 class DceTemplateError(Exception):
     pass
@@ -11,10 +13,14 @@ class UnknownEnvVarTemplateError(DceTemplateError):
     pass
 
 
-def render_template(source: str) -> str:
+def render_template(project_layout: ProjectLayout, source: str) -> str:
     env = SandboxedEnvironment()
 
-    return env.from_string(source=str(source)).render(env_var=resolve_env_var)
+    return env.from_string(source=str(source)).render(
+        env_var=resolve_env_var,
+        PROJECT_DIR=project_layout.project_dir.resolve(),
+        SRC_DIR=project_layout.src_dir.resolve(),
+    )
 
 
 def resolve_env_var(env_var: str, default: str | None = None) -> str:

--- a/tests/build_sources/test_build_runner.py
+++ b/tests/build_sources/test_build_runner.py
@@ -31,7 +31,7 @@ def stub_prepare(mocker):
     def _stub(prepared_list):
         items = list(prepared_list)
 
-        def side_effect(_ds):
+        def side_effect(_pl, _ds):
             return items.pop(0) if items else None
 
         return mocker.patch.object(build_runner, "prepare_source", side_effect=side_effect)

--- a/tests/templating/test_renderer.py
+++ b/tests/templating/test_renderer.py
@@ -3,10 +3,18 @@ import os
 import pytest
 import yaml
 
+from databao_context_engine.project.layout import ProjectLayout
 from databao_context_engine.templating.renderer import UnknownEnvVarTemplateError, render_template
 
 
-def test_render_template__plain_yaml():
+@pytest.fixture
+def unvalidated_project_layout(tmp_path):
+    tmp_project_dir = tmp_path.joinpath("unvalidated_project_dir")
+
+    return ProjectLayout(project_dir=tmp_project_dir, config_file=tmp_project_dir.joinpath("unused_config.ini"))
+
+
+def test_render_template__plain_yaml(unvalidated_project_layout: ProjectLayout):
     yaml_content = """
     attribute:
         subattribute: "test"
@@ -17,12 +25,12 @@ def test_render_template__plain_yaml():
 
     assert yaml.safe_load(yaml_content) == expected
 
-    result = render_template(yaml_content)
+    result = render_template(unvalidated_project_layout, yaml_content)
 
     assert yaml.safe_load(result) == expected
 
 
-def test_render_template__with_simple_calculation():
+def test_render_template__with_simple_calculation(unvalidated_project_layout: ProjectLayout):
     yaml_content = """
     attribute:
         subattribute: "test"
@@ -31,12 +39,12 @@ def test_render_template__with_simple_calculation():
 
     expected = {"attribute": {"subattribute": "test", "second_attribute": 124}}
 
-    result = render_template(yaml_content)
+    result = render_template(unvalidated_project_layout, yaml_content)
 
     assert yaml.safe_load(result) == expected
 
 
-def test_render_template__with_env_variable():
+def test_render_template__with_env_variable(unvalidated_project_layout: ProjectLayout):
     os.environ["DCE_DATASOURCE_PASSWORD"] = "mypassword"
 
     yaml_content = """
@@ -48,12 +56,12 @@ def test_render_template__with_env_variable():
 
     expected = {"attribute": {"subattribute": "test", "second_attribute": 124}, "secret": "mypassword"}
 
-    result = render_template(yaml_content)
+    result = render_template(unvalidated_project_layout, yaml_content)
 
     assert yaml.safe_load(result) == expected
 
 
-def test_render_template__with_env_variable_default():
+def test_render_template__with_env_variable_default(unvalidated_project_layout: ProjectLayout):
     os.environ["DCE_DATASOURCE_PASSWORD"] = "mypassword"
 
     yaml_content = """
@@ -70,12 +78,12 @@ def test_render_template__with_env_variable_default():
         "secret": "mypassword",
     }
 
-    result = render_template(yaml_content)
+    result = render_template(unvalidated_project_layout, yaml_content)
 
     assert yaml.safe_load(result) == expected
 
 
-def test_render_template__fails_if_env_variable_missing_and_no_default():
+def test_render_template__fails_if_env_variable_missing_and_no_default(unvalidated_project_layout: ProjectLayout):
     os.environ["DCE_DATASOURCE_PASSWORD"] = "mypassword"
 
     yaml_content = """
@@ -87,4 +95,24 @@ def test_render_template__fails_if_env_variable_missing_and_no_default():
     """
 
     with pytest.raises(UnknownEnvVarTemplateError):
-        render_template(yaml_content)
+        render_template(unvalidated_project_layout, yaml_content)
+
+
+def test_render_template__with_project_dir_variable(unvalidated_project_layout: ProjectLayout):
+    yaml_content = """
+    attribute:
+        subattribute: "test"
+        second_attribute: {{ 123 + 1 }}
+    path_relative_to_project: {{ PROJECT_DIR }}/my_file.txt
+    path_relative_to_src: {{ SRC_DIR }}/my_file.txt
+    """
+
+    expected = {
+        "attribute": {"subattribute": "test", "second_attribute": 124},
+        "path_relative_to_project": str(unvalidated_project_layout.project_dir.joinpath("my_file.txt").resolve()),
+        "path_relative_to_src": str(unvalidated_project_layout.src_dir.joinpath("my_file.txt").resolve()),
+    }
+
+    result = render_template(unvalidated_project_layout, yaml_content)
+
+    assert yaml.safe_load(result) == expected


### PR DESCRIPTION
# What?

The DBT plugin will need to read a Path in its config file.

To allow users to more easily add paths relative to their DCE project in that path, this PR adds two variables that can be used in the config file as Jinja variables: `PROJECT_DIR` and `SRC_DIR`

# How to use?

An example config file using those variables:
```yaml
my_path: {{ PROJECT_DIR }}/my_dbt_project/my_file.txt
my_src_path: {{ SRC_DIR }}/directory_in_src/my_file.txt
```