### PR TITLE
NEM-357: Fix Snowflake introspection by refactoring the connect methods

### DIFF
--- a/src/databao_context_engine/plugins/databases/athena/athena_introspector.py
+++ b/src/databao_context_engine/plugins/databases/athena/athena_introspector.py
@@ -67,7 +67,7 @@ class AthenaIntrospector(BaseIntrospector[AthenaConfigFile]):
     }
     supports_catalogs = True
 
-    def _connect(self, file_config: AthenaConfigFile):
+    def _connect(self, file_config: AthenaConfigFile, *, catalog: str | None = None) -> Any:
         return connect(**file_config.connection.to_athena_kwargs(), cursor_class=DictCursor)
 
     def _fetchall_dicts(self, connection, sql: str, params) -> list[dict]:
@@ -78,9 +78,6 @@ class AthenaIntrospector(BaseIntrospector[AthenaConfigFile]):
     def _get_catalogs(self, connection, file_config: AthenaConfigFile) -> list[str]:
         catalog = file_config.connection.catalog or self._resolve_pseudo_catalog_name(file_config)
         return [catalog]
-
-    def _connect_to_catalog(self, file_config: AthenaConfigFile, catalog: str):
-        return self._connect(file_config)
 
     def _sql_list_schemas(self, catalogs: list[str] | None) -> SQLQuery:
         if not catalogs:

--- a/src/databao_context_engine/plugins/databases/clickhouse/clickhouse_introspector.py
+++ b/src/databao_context_engine/plugins/databases/clickhouse/clickhouse_introspector.py
@@ -36,13 +36,10 @@ class ClickhouseIntrospector(BaseIntrospector[ClickhouseConfigFile]):
 
     supports_catalogs = True
 
-    def _connect(self, file_config: ClickhouseConfigFile):
+    def _connect(self, file_config: ClickhouseConfigFile, *, catalog: str | None = None):
         return clickhouse_connect.get_client(
             **file_config.connection.to_clickhouse_kwargs(),
         )
-
-    def _connect_to_catalog(self, file_config: ClickhouseConfigFile, catalog: str):
-        return self._connect(file_config)
 
     def _get_catalogs(self, connection, file_config: ClickhouseConfigFile) -> list[str]:
         return ["clickhouse"]

--- a/src/databao_context_engine/plugins/databases/duckdb/duckdb_introspector.py
+++ b/src/databao_context_engine/plugins/databases/duckdb/duckdb_introspector.py
@@ -24,12 +24,9 @@ class DuckDBIntrospector(BaseIntrospector[DuckDBConfigFile]):
     _IGNORED_SCHEMAS = {"information_schema", "pg_catalog"}
     supports_catalogs = True
 
-    def _connect(self, file_config: DuckDBConfigFile):
+    def _connect(self, file_config: DuckDBConfigFile, *, catalog: str | None = None):
         database_path = str(file_config.connection.database_path)
         return duckdb.connect(database=database_path)
-
-    def _connect_to_catalog(self, file_config: DuckDBConfigFile, catalog: str):
-        return self._connect(file_config)
 
     def _get_catalogs(self, connection, file_config: DuckDBConfigFile) -> list[str]:
         rows = self._fetchall_dicts(connection, "SELECT database_name FROM duckdb_databases();", None)

--- a/src/databao_context_engine/plugins/databases/mssql/mssql_introspector.py
+++ b/src/databao_context_engine/plugins/databases/mssql/mssql_introspector.py
@@ -55,15 +55,15 @@ class MSSQLIntrospector(BaseIntrospector[MSSQLConfigFile]):
     )
     supports_catalogs = True
 
-    def _connect(self, file_config: MSSQLConfigFile):
+    def _connect(self, file_config: MSSQLConfigFile, *, catalog: str | None = None):
         connection = file_config.connection
-        connection_string = self._create_connection_string_for_config(connection.to_mssql_kwargs())
-        return connect(connection_string)
 
-    def _connect_to_catalog(self, file_config: MSSQLConfigFile, catalog: str):
-        cfg = file_config.model_copy(deep=True)
-        cfg.connection.database = catalog
-        return self._connect(cfg)
+        connection_kwargs = connection.to_mssql_kwargs()
+        if catalog:
+            connection_kwargs["database"] = catalog
+
+        connection_string = self._create_connection_string_for_config(connection_kwargs)
+        return connect(connection_string)
 
     def _get_catalogs(self, connection, file_config: MSSQLConfigFile) -> list[str]:
         database = file_config.connection.database

--- a/src/databao_context_engine/plugins/databases/mysql/mysql_introspector.py
+++ b/src/databao_context_engine/plugins/databases/mysql/mysql_introspector.py
@@ -35,17 +35,17 @@ class MySQLIntrospector(BaseIntrospector[MySQLConfigFile]):
 
     supports_catalogs = True
 
-    def _connect(self, file_config: MySQLConfigFile):
+    def _connect(self, file_config: MySQLConfigFile, *, catalog: str | None = None):
+        connection_kwargs = file_config.connection.to_pymysql_kwargs()
+
+        if catalog:
+            connection_kwargs["database"] = catalog
+
         return pymysql.connect(
-            **file_config.connection.to_pymysql_kwargs(),
+            **connection_kwargs,
             cursorclass=pymysql.cursors.DictCursor,
             client_flag=CLIENT.MULTI_STATEMENTS | CLIENT.MULTI_RESULTS,
         )
-
-    def _connect_to_catalog(self, file_config: MySQLConfigFile, catalog: str):
-        cfg = file_config.model_copy(deep=True)
-        cfg.connection.database = catalog
-        return self._connect(cfg)
 
     def _get_catalogs(self, connection, file_config: MySQLConfigFile) -> list[str]:
         with connection.cursor() as cur:

--- a/src/databao_context_engine/plugins/databases/snowflake/snowflake_introspector.py
+++ b/src/databao_context_engine/plugins/databases/snowflake/snowflake_introspector.py
@@ -61,17 +61,16 @@ class SnowflakeIntrospector(BaseIntrospector[SnowflakeConfigFile]):
     _IGNORED_CATALOGS = {"STREAMLIT_APPS"}
     supports_catalogs = True
 
-    def _connect(self, file_config: SnowflakeConfigFile):
+    def _connect(self, file_config: SnowflakeConfigFile, *, catalog: str | None = None):
         connection = file_config.connection
         snowflake.connector.paramstyle = "qmark"
-        return snowflake.connector.connect(
-            **connection.to_snowflake_kwargs(),
-        )
+        connection_kwargs = connection.to_snowflake_kwargs()
+        if catalog:
+            connection_kwargs["database"] = catalog
 
-    def _connect_to_catalog(self, file_config: SnowflakeConfigFile, catalog: str):
-        cfg = dict(file_config.connection or {})
-        cfg["database"] = catalog
-        return snowflake.connector.connect(**cfg)
+        return snowflake.connector.connect(
+            **connection_kwargs,
+        )
 
     def _get_catalogs(self, connection, file_config: SnowflakeConfigFile) -> list[str]:
         database = file_config.connection.database

--- a/src/databao_context_engine/plugins/databases/sqlite/sqlite_introspector.py
+++ b/src/databao_context_engine/plugins/databases/sqlite/sqlite_introspector.py
@@ -22,14 +22,11 @@ class SQLiteIntrospector(BaseIntrospector[SQLiteConfigFile]):
     _PSEUDO_SCHEMA = "main"
     supports_catalogs = False
 
-    def _connect(self, file_config: SQLiteConfigFile):
+    def _connect(self, file_config: SQLiteConfigFile, *, catalog: str | None = None):
         database_path = str(file_config.connection.database_path)
         conn = sqlite3.connect(database_path)
         conn.text_factory = str
         return conn
-
-    def _connect_to_catalog(self, file_config: SQLiteConfigFile, catalog: str):
-        return self._connect(file_config)
 
     def _get_catalogs(self, connection, file_config: SQLiteConfigFile) -> list[str]:
         return [self._resolve_pseudo_catalog_name(file_config)]


### PR DESCRIPTION
# What?

The Snowflake introspection is broken because the code in `_connect_to_catalog` drifted compared to `_connect`.

This PR merges the two connect function into one, with an optional `catalog` argument. This will prevent such a drift in the future and should fix the Snowflake introspection (by allowing it to connect to a catalog)