### PR TITLE
Change Python version used in the workflows

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -15,7 +15,7 @@ on:
 
 jobs:
   build:
-    name: pre-commit on ${{ matrix.python-version }}
+    name: Build and run checks
 
     runs-on: ubuntu-latest
     permissions:
@@ -24,7 +24,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [ "3.12", "3.13" ]
+        python-version: [ "3.12" ]
 
     steps:
       - uses: actions/checkout@v5

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -37,7 +37,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [ "3.12", "3.13"]
+        python-version: [ "3.12", "3.13", "3.14"]
 
     permissions:
       contents: read


### PR DESCRIPTION
# What?

This PR changes the Python version we use in our GitHub workflows.

Specifically, it:
- only run the build checks on Python 3.12 (the results of the linters and mypy should be the same across Python versions)
- run all tests on 3.12, 3.13 and 3.14