### PR TITLE
[DBT Plugin] NEM-280: Extract column constraints from the DBT built-in tests

### DIFF
--- a/src/databao_context_engine/plugins/dbt/types.py
+++ b/src/databao_context_engine/plugins/dbt/types.py
@@ -1,6 +1,7 @@
 from dataclasses import dataclass
 from enum import Enum
 from pathlib import Path
+from typing import Literal
 
 from pydantic import BaseModel, Field
 
@@ -20,10 +21,38 @@ class DbtMaterialization(str, Enum):
 
 
 @dataclass(kw_only=True)
+class DbtSimpleConstraint:
+    type: Literal["unique", "not_null"]
+    is_enforced: bool
+    description: str | None = None
+
+
+@dataclass(kw_only=True)
+class DbtAcceptedValuesConstraint:
+    type: Literal["accepted_values"]
+    is_enforced: bool
+    description: str | None = None
+    accepted_values: list[str]
+
+
+@dataclass(kw_only=True)
+class DbtRelationshipConstraint:
+    type: Literal["relationships"]
+    is_enforced: bool
+    description: str | None = None
+    target_model: str
+    target_column: str
+
+
+DbtConstraint = DbtSimpleConstraint | DbtAcceptedValuesConstraint | DbtRelationshipConstraint
+
+
+@dataclass(kw_only=True)
 class DbtColumn:
     name: str
     type: str | None = None
     description: str | None = None
+    constraints: list[DbtConstraint] | None = None
 
 
 @dataclass(kw_only=True)

--- a/src/databao_context_engine/plugins/dbt/types_artifacts.py
+++ b/src/databao_context_engine/plugins/dbt/types_artifacts.py
@@ -1,10 +1,10 @@
 from dataclasses import dataclass
-from typing import Annotated, Literal
+from typing import Annotated, Any, Literal
 
 from pydantic import BaseModel, Discriminator, Field
 
 
-class DbtManifestNodeConfig(BaseModel):
+class DbtManifestModelConfig(BaseModel):
     materialized: str
 
 
@@ -21,17 +21,36 @@ class DbtManifestModel(BaseModel):
     database: str
     schema_: str = Field(alias="schema")
     description: str | None = None
-    config: DbtManifestNodeConfig | None = None
+    config: DbtManifestModelConfig | None = None
     columns: dict[str, DbtManifestColumn]
     depends_on: dict[str, list[str]] | None = None
     primary_key: list[str] | None = None
 
 
+class DbtManifestTestConfig(BaseModel):
+    severity: str
+
+
+class DbtManifestTestMetadata(BaseModel):
+    name: str | None = None
+    kwargs: dict[str, Any] | None = None
+
+
+class DbtManifestTest(BaseModel):
+    resource_type: Literal["test"]
+    unique_id: str
+    attached_node: str | None = None
+    column_name: str | None = None
+    description: str | None = None
+    test_metadata: DbtManifestTestMetadata | None = None
+    config: DbtManifestTestConfig | None = None
+
+
 class DbtManifestOtherNode(BaseModel):
-    resource_type: Literal["seed", "analysis", "test", "operation", "sql_operation", "snapshot"]
+    resource_type: Literal["seed", "analysis", "operation", "sql_operation", "snapshot"]
 
 
-DbtManifestNode = Annotated[DbtManifestModel | DbtManifestOtherNode, Discriminator("resource_type")]
+DbtManifestNode = Annotated[DbtManifestModel | DbtManifestTest | DbtManifestOtherNode, Discriminator("resource_type")]
 
 
 class DbtManifest(BaseModel):


### PR DESCRIPTION
# What?

DBT offers a feature to add some test on your data when you're transforming it into a new model. We can use those "data tests" to understand constraints met by the columns in the models.

# How?

For now, only the 4 [built-in test types](https://docs.getdbt.com/reference/resource-properties/data-tests#out-of-the-box-data-tests) have been handled.

# Next steps

There is a lot more tests that we could recognise and could be interesting. There is an official [DBT utils library](https://github.com/dbt-labs/dbt-utils) that we could handle as an improvement. I also found [this library](https://github.com/metaplane/dbt-expectations) (dbt-expectations) that seems popular and could be handled as well